### PR TITLE
Clarify build-system as setuptools+wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,6 @@ exclude = '''
 )
 '''
 
-
-
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Looking at `setup.py`, this project is built with `setuptools` and `wheel`. To make it PEP-518 compliant (which makes the project interpretable by _any_ build tool), this PR codifies what already exists. There are no other behavior or semantics changes to the project or its code.