### PR TITLE
better error handling

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -207,7 +207,7 @@ class NucleusClient:
             )
 
         def exception_handler(request, exception):
-            logger.error(request, exception)
+            logger.error(exception)
 
         def preprocess_payload(item):
             image = open(item.get(IMAGE_URL_KEY), "rb")
@@ -243,8 +243,11 @@ class NucleusClient:
             # don't forget to close all open files
             map(lambda x: x[IMAGE_KEY][1].close(), payloads)
 
+            # response object will be None if an error occurred
             async_responses = [
-                response if response.status_code == 200 else error()
+                response
+                if (response and response.status_code == 200)
+                else error()
                 for response in async_responses
             ]
             responses.extend(async_responses)
@@ -267,8 +270,7 @@ class NucleusClient:
             )
 
         def exception_handler(request, exception):
-            logger.error(request, exception)
-            return default_error(request.json())
+            logger.error(exception)
 
         items = payload[ITEMS_KEY]
         payloads = [
@@ -290,7 +292,9 @@ class NucleusClient:
         )
 
         async_responses = [
-            response if response.status_code == 200 else default_error(payload)
+            response
+            if (response and response.status_code == 200)
+            else default_error(payload)
             for response, payload in zip(async_responses, payloads)
         ]
 


### PR DESCRIPTION
Resolve Max's bug of periodic image upload bug by making error handling more robust.  There is actually a couple of things going on in the old code:
(i) A logging error because an Async Request object cannot be serialized to string format
(ii) A failed call to response.json() when the response was invalid

Basically the TL;DR is that it used to be the case that if one request failed, the whole upload failed.  Now we are robust to request failures and will continue uploading the rest.