### PR TITLE
Sasha/adjust params

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -92,7 +92,7 @@ from .payload_constructor import (
 )
 from .constants import (
     NUCLEUS_ENDPOINT,
-    DEFAULT_TIMEOUT,
+    DEFAULT_NETWORK_TIMEOUT_SEC,
     ERRORS_KEY,
     ERROR_ITEMS,
     ERROR_PAYLOAD,
@@ -1022,7 +1022,7 @@ class NucleusClient:
                 session=sess,
                 files=payload,
                 auth=(self.api_key, ""),
-                timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_NETWORK_TIMEOUT_SEC,
             )
         else:
             post = requests_command(
@@ -1031,7 +1031,7 @@ class NucleusClient:
                 json=payload,
                 headers={"Content-Type": "application/json"},
                 auth=(self.api_key, ""),
-                timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_NETWORK_TIMEOUT_SEC,
             )
         return post
 
@@ -1055,7 +1055,7 @@ class NucleusClient:
             json=payload,
             headers={"Content-Type": "application/json"},
             auth=(self.api_key, ""),
-            timeout=DEFAULT_TIMEOUT,
+            timeout=DEFAULT_NETWORK_TIMEOUT_SEC,
         )
         logger.info("API request has response code %s", response.status_code)
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -92,6 +92,7 @@ from .payload_constructor import (
 )
 from .constants import (
     NUCLEUS_ENDPOINT,
+    DEFAULT_TIMEOUT,
     ERRORS_KEY,
     ERROR_ITEMS,
     ERROR_PAYLOAD,
@@ -1021,6 +1022,7 @@ class NucleusClient:
                 session=sess,
                 files=payload,
                 auth=(self.api_key, ""),
+                timeout=DEFAULT_TIMEOUT,
             )
         else:
             post = requests_command(
@@ -1029,6 +1031,7 @@ class NucleusClient:
                 json=payload,
                 headers={"Content-Type": "application/json"},
                 auth=(self.api_key, ""),
+                timeout=DEFAULT_TIMEOUT,
             )
         return post
 
@@ -1052,6 +1055,7 @@ class NucleusClient:
             json=payload,
             headers={"Content-Type": "application/json"},
             auth=(self.api_key, ""),
+            timeout=DEFAULT_TIMEOUT,
         )
         logger.info("API request has response code %s", response.status_code)
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -657,7 +657,7 @@ class NucleusClient:
             Union[BoxPrediction, PolygonPrediction, SegmentationPrediction]
         ],
         update: bool,
-        batch_size: int = 100,
+        batch_size: int = 5000,
     ):
         """
         Uploads model outputs as predictions for a model_run. Returns info about the upload.

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -1,4 +1,5 @@
 NUCLEUS_ENDPOINT = "https://api.scale.com/v1/nucleus"
+DEFAULT_TIMEOUT = 30
 ITEMS_KEY = "items"
 ITEM_KEY = "item"
 REFERENCE_ID_KEY = "reference_id"

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -1,5 +1,5 @@
 NUCLEUS_ENDPOINT = "https://api.scale.com/v1/nucleus"
-DEFAULT_TIMEOUT = 60
+DEFAULT_NETWORK_TIMEOUT_SEC = 60
 ITEMS_KEY = "items"
 ITEM_KEY = "item"
 REFERENCE_ID_KEY = "reference_id"

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -1,5 +1,5 @@
 NUCLEUS_ENDPOINT = "https://api.scale.com/v1/nucleus"
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 60
 ITEMS_KEY = "items"
 ITEM_KEY = "item"
 REFERENCE_ID_KEY = "reference_id"


### PR DESCRIPTION
Increase batch size for model predictions, add timeout to network requests.

While trying to upload a large dataset, I found that my upload script would occasionally hang indefinitely, and I would have to quit the program and re-run.  I think this happened because without a timeout parameter, the request library will keep the connection open forever even if it hears no response from the server.  In the case of a poor internet connection, this leads to hanging.  In my opinion, better for upload to fail due to timeout than to hang!