### PR TITLE
GET a slice and all the data of each dataset item

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -920,7 +920,7 @@ class NucleusClient:
         return Slice(slice_id, self)
 
     def slice_info(
-        self, slice_id: str, id_type: str = DATASET_ITEM_ID_KEY
+        self, slice_id: str
     ) -> dict:
         """
         This endpoint provides information about specified slice.
@@ -939,7 +939,7 @@ class NucleusClient:
         """
         response = self._make_request(
             {},
-            f"slice/{slice_id}?idType={id_type}",
+            f"slice/{slice_id}",
             requests_command=requests.get,
         )
         return response

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -15,22 +15,18 @@ class Slice:
         self.slice_id = slice_id
         self._client = client
 
-    def info(self, id_type: str = DATASET_ITEM_ID_KEY) -> dict:
+    def info(self) -> dict:
         """
         This endpoint provides information about specified slice.
-
-        :param
-        id_type: the type of IDs you want in response (either "reference_id" or "dataset_item_id")
-        to identify the DatasetItems
 
         :return:
         {
             "name": str,
             "dataset_id": str,
-            "dataset_item_ids" or "reference_ids": List[str],
+            "dataset_items",
         }
         """
-        return self._client.slice_info(self.slice_id, id_type)
+        return self._client.slice_info(self.slice_id)
 
     def append(
         self,


### PR DESCRIPTION
Changed the function to GET a slice without specifying a querystring. The function now retrieves a slice and all the dataset item information for each of those in said slice.