### PR TITLE
change test files to S3 urls that are accessible

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -102,7 +102,7 @@ class Dataset:
         self,
         annotations: List[Union[BoxAnnotation, PolygonAnnotation]],
         update: Optional[bool] = DEFAULT_ANNOTATION_UPDATE_MODE,
-        batch_size: int = 20,
+        batch_size: int = 5000,
     ) -> dict:
         """
         Uploads ground truth annotations for a given dataset.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,11 +17,11 @@ TEST_MODEL_RUN = "[PyTest] Test Model Run Reference"
 TEST_DATASET_NAME = "[PyTest] Test Dataset"
 TEST_SLICE_NAME = "[PyTest] Test Slice"
 TEST_IMG_URLS = [
-    "s3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/6dd63871-831611a6.jpg",
-    "s3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/82c1005c-e2d1d94f.jpg",
-    "s3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/7f2e1814-6591087d.jpg",
-    "s3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/06924f46-1708b96f.jpg",
-    "s3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/89b42832-10d662f4.jpg",
+    "s3://scaleapi-cust-lidar/Hesai/raw_data/2019-5-11/hesai_data_1557540003/undistorted/front_camera/1557540143.650423lf.jpg",
+    "s3://scaleapi-cust-lidar/Hesai/raw_data/2019-5-11/hesai_data_1557540003/undistorted/back_camera/1557540143.600352lf.jpg",
+    "s3://scaleapi-cust-lidar/Hesai/raw_data/2019-5-11/hesai_data_1557540003/undistorted/right_camera/1557540143.681730lf.jpg",
+    "s3://scaleapi-cust-lidar/Hesai/raw_data/2019-5-11/hesai_data_1557540003/undistorted/front_left_camera/1557540143.639619lf.jpg",
+    "s3://scaleapi-cust-lidar/Hesai/raw_data/2019-5-11/hesai_data_1557540003/undistorted/front_right_camera/1557540143.661212lf.jpg",
 ]
 TEST_DATASET_ITEMS = [
     DatasetItem(TEST_IMG_URLS[0], "1"),
@@ -61,6 +61,7 @@ def s3_sign(bucket, key):
         },
         ExpiresIn=PRESIGN_EXPIRY_SECONDS,
     )
+
 
 def reference_id_from_url(url):
     return Path(url).name


### PR DESCRIPTION
TL;DR: pytest is currently broken due to the same S3 permissioning challenges we've been seeing with ingestion.  The easiest fix I found was just changing the seed images to images from pandaset.

Previously, image uploads from urls were not being copied. Now that the scaleapi PR copies them, we run into a problem where we get access denied errors on BDD images. I switched to using Pandaset images for pytest (which are stored in a different S3 bucket) and it fixed the problem.

