### PR TITLE
higher timeout based on timeout settings on server-side

### DIFF
--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -1,5 +1,5 @@
 NUCLEUS_ENDPOINT = "https://api.scale.com/v1/nucleus"
-DEFAULT_NETWORK_TIMEOUT_SEC = 100
+DEFAULT_NETWORK_TIMEOUT_SEC = 120
 ITEMS_KEY = "items"
 ITEM_KEY = "item"
 REFERENCE_ID_KEY = "reference_id"

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -1,5 +1,5 @@
 NUCLEUS_ENDPOINT = "https://api.scale.com/v1/nucleus"
-DEFAULT_NETWORK_TIMEOUT_SEC = 60
+DEFAULT_NETWORK_TIMEOUT_SEC = 100
 ITEMS_KEY = "items"
 ITEM_KEY = "item"
 REFERENCE_ID_KEY = "reference_id"


### PR DESCRIPTION
Playing around with the API endpoints, I was able to observe a timeout happen naturally, and was able to cause timeout errors when having the endpoint sleep before doing any computations.

The original purpose of introducing the timeout was to prevent connections from hanging indefinitely. The client side timeout should definitely be higher that the corresponding server side configuration, since it should never be the case that the client errors out when the server would have successfully serviced the request.

I think this should at least alleviate the user pain, although I would also want to understand more deeply why their upload was taking > 60 sec per batch