### PR TITLE
Simplify error handling + Export Autotags

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,9 @@ pip3 install poetry
 poetry install
 ```
 
-Please install the pre-commit hooks by running the following commands:
+Please install the pre-commit hooks by running the following command:
 ```python
-pip install pre-commit
-pre-commit install
+poetry run pre-commit install
 ```
 
 **Best practices for testing:**

--- a/conftest.py
+++ b/conftest.py
@@ -29,34 +29,8 @@ API_KEY = os.environ["NUCLEUS_PYTEST_API_KEY"]
 
 
 @pytest.fixture(scope="session")
-def monkeypatch_session(request):
-    """This workaround is needed to allow monkeypatching in session-scoped fixtures.
-
-    See https://github.com/pytest-dev/pytest/issues/363
-    """
-    from _pytest.monkeypatch import MonkeyPatch
-
-    mpatch = MonkeyPatch()
-    yield mpatch
-    mpatch.undo()
-
-
-@pytest.fixture(scope="session")
-def CLIENT(monkeypatch_session):
+def CLIENT():
     client = nucleus.NucleusClient(API_KEY)
-
-    # Change _make_request to raise AsssertionErrors when the
-    # HTTP status code is not successful, so that tests fail if
-    # the request was unsuccessful.
-    def _make_request_patch(
-        payload: dict, route: str, requests_command=requests.post
-    ) -> dict:
-        response = client._make_request_raw(payload, route, requests_command)
-        if response.status_code not in SUCCESS_STATUS_CODES:
-            response.raise_for_status()
-        return response.json()
-
-    monkeypatch_session.setattr(client, "make_request", _make_request_patch)
     return client
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -52,13 +52,11 @@ def CLIENT(monkeypatch_session):
         payload: dict, route: str, requests_command=requests.post
     ) -> dict:
         response = client._make_request_raw(payload, route, requests_command)
-        assert response.status_code in SUCCESS_STATUS_CODES, (
-            f"HTTP response had status code: {response.status_code}. "
-            f"Full JSON: {response.json()}"
-        )
+        if response.status_code not in SUCCESS_STATUS_CODES:
+            response.raise_for_status()
         return response.json()
 
-    monkeypatch_session.setattr(client, "_make_request", _make_request_patch)
+    monkeypatch_session.setattr(client, "make_request", _make_request_patch)
     return client
 
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -167,7 +167,7 @@ class NucleusClient:
         Lists available models in your repo.
         :return: model_ids
         """
-        model_objects = self._make_request({}, "models/", requests.get)
+        model_objects = self.make_request({}, "models/", requests.get)
 
         return [
             Model(
@@ -185,14 +185,14 @@ class NucleusClient:
         Lists available datasets in your repo.
         :return: { datasets_ids }
         """
-        return self._make_request({}, "dataset/", requests.get)
+        return self.make_request({}, "dataset/", requests.get)
 
     def get_dataset_items(self, dataset_id) -> List[DatasetItem]:
         """
         Gets all the dataset items inside your repo as a json blob.
         :return [ DatasetItem ]
         """
-        response = self._make_request(
+        response = self.make_request(
             {}, f"dataset/{dataset_id}/datasetItems", requests.get
         )
         dataset_items = response.get("dataset_items", None)
@@ -235,7 +235,7 @@ class NucleusClient:
         :param model_run_id: internally controlled model_run_id
         :return: model_run
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"modelRun/{model_run_id}", requests.delete
         )
 
@@ -254,7 +254,7 @@ class NucleusClient:
             payload["last_n_tasks"] = str(last_n_tasks)
         if name:
             payload["name"] = name
-        response = self._make_request(payload, "dataset/create_from_project")
+        response = self.make_request(payload, "dataset/create_from_project")
         return Dataset(response[DATASET_ID_KEY], self)
 
     def create_dataset(
@@ -271,7 +271,7 @@ class NucleusClient:
         :param annotation_metadata_schema -- optional dictionary to define annotation metadata schema
         :return: new Dataset object
         """
-        response = self._make_request(
+        response = self.make_request(
             {
                 NAME_KEY: name,
                 ANNOTATION_METADATA_SCHEMA_KEY: annotation_metadata_schema,
@@ -289,7 +289,7 @@ class NucleusClient:
         :param payload: { "name": str }
         :return: { "dataset_id": str, "name": str }
         """
-        return self._make_request({}, f"dataset/{dataset_id}", requests.delete)
+        return self.make_request({}, f"dataset/{dataset_id}", requests.delete)
 
     def delete_dataset_item(
         self, dataset_id: str, item_id: str = None, reference_id: str = None
@@ -302,11 +302,11 @@ class NucleusClient:
         :return: { "dataset_id": str, "name": str }
         """
         if item_id:
-            return self._make_request(
+            return self.make_request(
                 {}, f"dataset/{dataset_id}/{item_id}", requests.delete
             )
         else:  # Assume reference_id is provided
-            return self._make_request(
+            return self.make_request(
                 {},
                 f"dataset/{dataset_id}/refloc/{reference_id}",
                 requests.delete,
@@ -566,7 +566,7 @@ class NucleusClient:
         with self.tqdm_bar(total=total_batches) as pbar:
             for batch in tqdm_batches:
                 payload = construct_annotation_payload(batch, update)
-                response = self._make_request(
+                response = self.make_request(
                     payload, f"dataset/{dataset_id}/annotate"
                 )
                 pbar.update(1)
@@ -582,7 +582,7 @@ class NucleusClient:
 
             for s_batch in semseg_batches:
                 payload = construct_segmentation_payload(s_batch, update)
-                response = self._make_request(
+                response = self.make_request(
                     payload, f"dataset/{dataset_id}/annotate_segmentation"
                 )
                 pbar.update(1)
@@ -607,9 +607,7 @@ class NucleusClient:
         :param dataset_id: id of the dataset
         :return: {"ingested_tasks": int, "ignored_tasks": int, "pending_tasks": int}
         """
-        return self._make_request(
-            payload, f"dataset/{dataset_id}/ingest_tasks"
-        )
+        return self.make_request(payload, f"dataset/{dataset_id}/ingest_tasks")
 
     def add_model(
         self, name: str, reference_id: str, metadata: Optional[Dict] = None
@@ -624,7 +622,7 @@ class NucleusClient:
         :param metadata: An optional arbitrary metadata blob for the model.
         :return: { "model_id": str }
         """
-        response = self._make_request(
+        response = self.make_request(
             construct_model_creation_payload(name, reference_id, metadata),
             "models/add",
         )
@@ -659,7 +657,7 @@ class NucleusClient:
         }
         :return: new ModelRun object
         """
-        response = self._make_request(
+        response = self.make_request(
             payload, f"dataset/{dataset_id}/modelRun/create"
         )
         if response.get(STATUS_CODE_KEY, None):
@@ -723,7 +721,7 @@ class NucleusClient:
                 batch,
                 update,
             )
-            response = self._make_request(
+            response = self.make_request(
                 batch_payload, f"modelRun/{model_run_id}/predict"
             )
             if STATUS_CODE_KEY in response:
@@ -738,7 +736,7 @@ class NucleusClient:
 
         for s_batch in s_batches:
             payload = construct_segmentation_payload(s_batch, update)
-            response = self._make_request(
+            response = self.make_request(
                 payload, f"modelRun/{model_run_id}/predict_segmentation"
             )
             # pbar.update(1)
@@ -783,7 +781,7 @@ class NucleusClient:
         """
         if payload is None:
             payload = {}
-        return self._make_request(payload, f"modelRun/{model_run_id}/commit")
+        return self.make_request(payload, f"modelRun/{model_run_id}/commit")
 
     def dataset_info(self, dataset_id: str):
         """
@@ -797,7 +795,7 @@ class NucleusClient:
                 'slice_ids': List[str]
             }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"dataset/{dataset_id}/info", requests.get
         )
 
@@ -816,7 +814,7 @@ class NucleusClient:
             "metadata": Dict[str, Any],
         }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"modelRun/{model_run_id}/info", requests.get
         )
 
@@ -826,7 +824,7 @@ class NucleusClient:
         :param reference_id: reference_id of a dataset_item
         :return:
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"dataset/{dataset_id}/refloc/{reference_id}", requests.get
         )
 
@@ -840,7 +838,7 @@ class NucleusClient:
             "annotations": List[BoxPrediction],
         }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"modelRun/{model_run_id}/refloc/{ref_id}", requests.get
         )
 
@@ -851,7 +849,7 @@ class NucleusClient:
         :param i: absolute number of the dataset_item
         :return:
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"dataset/{dataset_id}/iloc/{i}", requests.get
         )
 
@@ -865,7 +863,7 @@ class NucleusClient:
             "annotations": List[BoxPrediction],
         }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"modelRun/{model_run_id}/iloc/{i}", requests.get
         )
 
@@ -880,7 +878,7 @@ class NucleusClient:
             "annotations": List[Box2DAnnotation],
         }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"dataset/{dataset_id}/loc/{dataset_item_id}", requests.get
         )
 
@@ -894,7 +892,7 @@ class NucleusClient:
             "annotations": List[BoxPrediction],
         }
         """
-        return self._make_request(
+        return self.make_request(
             {}, f"modelRun/{model_run_id}/loc/{dataset_item_id}", requests.get
         )
 
@@ -920,7 +918,7 @@ class NucleusClient:
         }
         :return: new Slice object
         """
-        response = self._make_request(
+        response = self.make_request(
             payload, f"dataset/{dataset_id}/create_slice"
         )
         return Slice(response[SLICE_ID_KEY], self)
@@ -951,7 +949,7 @@ class NucleusClient:
             "dataset_item_ids": List[str],
         }
         """
-        response = self._make_request(
+        response = self.make_request(
             {},
             f"slice/{slice_id}",
             requests_command=requests.get,
@@ -968,7 +966,7 @@ class NucleusClient:
         :return:
         {}
         """
-        response = self._make_request(
+        response = self.make_request(
             {},
             f"slice/{slice_id}",
             requests_command=requests.delete,
@@ -1006,9 +1004,7 @@ class NucleusClient:
         if reference_ids:
             ids_to_append[REFERENCE_IDS_KEY] = reference_ids
 
-        response = self._make_request(
-            ids_to_append, f"slice/{slice_id}/append"
-        )
+        response = self.make_request(ids_to_append, f"slice/{slice_id}/append")
         return response
 
     def list_autotags(self, dataset_id: str) -> List[str]:
@@ -1017,7 +1013,7 @@ class NucleusClient:
         :param dataset_id: internally controlled dataset_id
         :return: List[str] representing autotag_ids
         """
-        response = self._make_request(
+        response = self.make_request(
             {},
             f"{dataset_id}/list_autotags",
             requests_command=requests.get,
@@ -1035,7 +1031,7 @@ class NucleusClient:
         :return:
         {}
         """
-        response = self._make_request(
+        response = self.make_request(
             {},
             f"model/{model_id}",
             requests_command=requests.delete,
@@ -1043,21 +1039,21 @@ class NucleusClient:
         return response
 
     def create_custom_index(self, dataset_id: str, embeddings_url: str):
-        return self._make_request(
+        return self.make_request(
             {EMBEDDINGS_URL_KEY: embeddings_url},
             f"indexing/{dataset_id}",
             requests_command=requests.post,
         )
 
     def check_index_status(self, job_id: str):
-        return self._make_request(
+        return self.make_request(
             {},
             f"indexing/{job_id}",
             requests_command=requests.get,
         )
 
     def delete_custom_index(self, dataset_id: str):
-        return self._make_request(
+        return self.make_request(
             {},
             f"indexing/{dataset_id}",
             requests_command=requests.delete,
@@ -1132,7 +1128,7 @@ class NucleusClient:
 
         return response
 
-    def _make_request(
+    def make_request(
         self, payload: dict, route: str, requests_command=requests.post
     ) -> dict:
         """
@@ -1149,6 +1145,7 @@ class NucleusClient:
         if getattr(response, "status_code") not in SUCCESS_STATUS_CODES:
             logger.warning(response)
 
-        return (
-            response.json()
-        )  # TODO: this line fails if response has code == 404
+        if response.status_code == 404:
+            raise response.raise_for_status()
+
+        return response.json()

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -416,7 +416,9 @@ class NucleusClient:
                 (ITEMS_KEY, (None, json.dumps(batch), "application/json"))
             ]
             for item in batch:
-                image = open(item.get(IMAGE_URL_KEY), "rb")
+                image = open(  # pylint: disable=R1732
+                    item.get(IMAGE_URL_KEY), "rb"  # pylint: disable=R1732
+                )  # pylint: disable=R1732
                 img_name = os.path.basename(image.name)
                 img_type = (
                     f"image/{os.path.splitext(image.name)[1].strip('.')}"

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -161,7 +161,7 @@ class NucleusClient:
             self.tqdm_bar = tqdm_notebook.tqdm
 
     def __repr__(self):
-        return f"NucleusClient(api_key='{self.api_key}', use_notebook={self._use_notebook}, endpoint='{self.endpoint}'')"
+        return f"NucleusClient(api_key='{self.api_key}', use_notebook={self._use_notebook}, endpoint='{self.endpoint}')"
 
     def __eq__(self, other):
         if self.api_key == other.api_key:

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -20,6 +20,8 @@ from .constants import (
 )
 from .payload_constructor import construct_model_run_creation_payload
 
+import requests
+
 
 class Dataset:
     """
@@ -60,6 +62,25 @@ class Dataset:
     @property
     def items(self) -> List[DatasetItem]:
         return self._client.get_dataset_items(self.id)
+
+    def autotag_scores(self, autotag_name, for_scores_greater_than=0):
+        """Export the autotag scores above a threshold, largest scores first.
+
+        If you have pandas installed, you can create a pandas dataframe using
+
+        pandas.Dataframe(dataset.autotag_scores(autotag_name))
+
+        :return: dictionary of the form
+            {'ref_ids': List[str],
+             'datset_item_ids': List[str],
+             'score': List[float]}
+        """
+        response = self._client.make_request(
+            payload={},
+            route=f"autotag/{self.id}/{autotag_name}/{for_scores_greater_than}",
+            requests_command=requests.get,
+        )
+        return response
 
     def info(self) -> dict:
         """

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1,23 +1,22 @@
-from typing import List, Dict, Any, Optional
-
-from nucleus.utils import format_dataset_item_response
-from .dataset_item import DatasetItem
-from .annotation import (
-    Annotation,
-)
-from .constants import (
-    DATASET_NAME_KEY,
-    DATASET_MODEL_RUNS_KEY,
-    DATASET_SLICES_KEY,
-    DATASET_LENGTH_KEY,
-    DATASET_ITEM_IDS_KEY,
-    REFERENCE_IDS_KEY,
-    NAME_KEY,
-    DEFAULT_ANNOTATION_UPDATE_MODE,
-)
-from .payload_constructor import construct_model_run_creation_payload
+from typing import Any, Dict, List, Optional
 
 import requests
+
+from nucleus.utils import format_dataset_item_response
+
+from .annotation import Annotation
+from .constants import (
+    DATASET_ITEM_IDS_KEY,
+    DATASET_LENGTH_KEY,
+    DATASET_MODEL_RUNS_KEY,
+    DATASET_NAME_KEY,
+    DATASET_SLICES_KEY,
+    DEFAULT_ANNOTATION_UPDATE_MODE,
+    NAME_KEY,
+    REFERENCE_IDS_KEY,
+)
+from .dataset_item import DatasetItem
+from .payload_constructor import construct_model_run_creation_payload
 
 
 class Dataset:

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -22,3 +22,12 @@ class DatasetItemRetrievalError(Exception):
     def __init__(self, message="Could not retrieve dataset items"):
         self.message = message
         super().__init__(self.message)
+
+
+class NucleusAPIError(Exception):
+    def __init__(self, endpoint, command, response):
+        message = f"Tried to {command.__name__} {endpoint}, but received {response.status_code}: {response.reason}."
+        if hasattr(response, "text"):
+            if response.text:
+                message += f"\nThe detailed error is:\n{response.text}"
+        super().__init__(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,10 @@ documentation = "https://dashboard.scale.com/nucleus/docs/api"
 packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.1"
 grequests = "^0.6.0"
 requests = "^2.25.1"
 tqdm = "^4.60.0"
-boto3 = "^1.17.53"
-mypy = "^0.812"
-coverage = "^5.5"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
 
 [tool.poetry.dev-dependencies]
@@ -49,6 +46,7 @@ black = "^20.8b1"
 flake8 = "^3.9.1"
 mypy = "^0.812"
 coverage = "^5.5"
+pre-commit = "^2.12.1"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.1.1"
+version = "0.1.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -129,6 +129,13 @@ def test_dataset_list_autotags(CLIENT, dataset):
     assert autotag_response == []
 
 
+def test_dataset_export_autotag_scores_raises_not_found(CLIENT):
+    client.get_dataset("ds_bwhjbyfb8mjj0ykagxf0")
+
+    # TODO: if/when we can create autotags via api, create one instead.
+    dataset.autotag_scores(autotag_name="red_car_v2")
+
+
 def test_slice_create_and_delete_and_list(dataset):
     # Dataset upload
     ds_items = []


### PR DESCRIPTION
* I decided to simplify our error handling in order to auto-surface errors from the backend. Currently we were burying or ignoring most. Eventually we can make the error classes more specific, but IMO anytime there is a bad response we should raise an error and print out what the backend thinks the issue is.
* I added tests showing that this surfaces the backend error, and that we get back autotag scores as expecated from the backend.
* The test can only run if you have access to the API_KEY for the default user used in our CircleCI setup, otherwise it will skip it.

As of Friday 1:12, this depends on a change that has not deployed yet and so it is expected to fail (I tested against a locally running backend server).