### PR TITLE
Add error check for duplicate reference ids

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import List, Dict, Any, Optional
 
 from nucleus.utils import format_dataset_item_response
@@ -158,6 +159,19 @@ class Dataset:
             'ignored_items': int,
         }
         """
+        ref_ids = []
+        for dataset_item in dataset_items:
+            if dataset_item.reference_id is not None:
+                ref_ids.append(dataset_item.reference_id)
+        if len(ref_ids) != len(set(ref_ids)):
+            duplicates = {
+                f"{key}": f"Count: {value}"
+                for key, value in Counter(ref_ids).items()
+            }
+            raise ValueError(
+                "Duplicate reference ids found among dataset_items: %s"
+                % duplicates
+            )
         return self._client.populate_dataset(
             self.id,
             dataset_items,

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -57,7 +57,7 @@ def dataset(CLIENT):
     yield ds
 
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_box_gt_upload(dataset):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -58,7 +58,7 @@ def dataset(CLIENT):
     yield ds
 
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_dataset_create_and_delete(CLIENT):
@@ -73,7 +73,7 @@ def test_dataset_create_and_delete(CLIENT):
 
     # Deletion
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_dataset_append(dataset):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -127,3 +127,19 @@ def test_dataset_list_autotags(CLIENT, dataset):
     # List of Autotags should be empty
     autotag_response = CLIENT.list_autotags(dataset.id)
     assert autotag_response == []
+
+
+def test_raises_error_for_duplicate():
+    fake_dataset = Dataset("fake", NucleusClient("fake"))
+    with pytest.raises(ValueError) as error:
+        fake_dataset.append(
+            [
+                DatasetItem("fake", "duplicate"),
+                DatasetItem("fake", "duplicate"),
+            ]
+        )
+    assert (
+        str(error.value)
+        == "Duplicate reference ids found among dataset_items:"
+        " {'duplicate': 'Count: 2'}"
+    )

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -34,7 +34,7 @@ def dataset(CLIENT):
     yield ds
 
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_index_integration(dataset):

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -65,7 +65,7 @@ def model_run(CLIENT):
     yield run
 
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
     response = CLIENT.delete_model(model.id)
     assert response == {}
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -16,7 +16,7 @@ def dataset(CLIENT):
     yield ds
 
     response = CLIENT.delete_dataset(ds.id)
-    assert response == {}
+    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_reprs():


### PR DESCRIPTION
Throw an error in the python client if they are trying to append duplicate reference ids. This is one common reason for error that we can fail fast on.

Also, fix all the broken tests due to the change in response for dataset deletion.

Primary reviewer: Jihan