### PR TITLE
Remove Grequests Dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   build_test:
     docker:
-      - image: python:3.7-slim-buster
+      - image: python:3.6-slim-buster
     resource_class: small
     steps:
       - checkout # checkout source code to working directory
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Black Formatting Check # Only validation, without re-formatting
           command: |
-            poetry run black --check -t py37 .
+            poetry run black --check -t py36 .
       - run:
           name: Flake8 Lint Check # Uses setup.cfg for configuration
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   build_test:
     docker:
-      - image: python:3.6-slim-buster
+      - image: python:3.7-slim-buster
     resource_class: small
     steps:
       - checkout # checkout source code to working directory
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Black Formatting Check # Only validation, without re-formatting
           command: |
-            poetry run black --check -t py36 .
+            poetry run black --check -t py37 .
       - run:
           name: Flake8 Lint Check # Uses setup.cfg for configuration
           command: |

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,3 @@
-# grequests must be imported before any module not designed for reentrancy,
-# because it relies on aggressive monkey patching that breaks if done after many
-# other common module imports, e.g. ssl.
-#
-# So we import it before everything else. For details see:
-# https://github.com/gevent/gevent/issues/1016#issuecomment-328530533
-# https://github.com/spyoungtech/grequests/issues/8
-import grequests
-
-################
-
 import logging
 import os
 

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -53,7 +53,7 @@ class Annotation:
         )
 
     def to_json(self) -> str:
-        return json.dumps(self.to_payload())
+        return json.dumps(self.to_payload(), allow_nan=False)
 
 
 @dataclass

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -225,7 +225,7 @@ class Dataset:
         return self._client.populate_dataset(
             self.id,
             dataset_items,
-            force=update,
+            update=update,
             batch_size=batch_size,
         )
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -216,7 +216,10 @@ class Dataset:
 
         if len(dataset_items) > WARN_FOR_LARGE_UPLOAD and not asynchronous:
             print(
-                "WARNING: for large uploads we recommend uploading your images remotely to a cloud storage provider and then using asynchronous=True."
+                "Tip: for large uploads, get faster performance by importing your data "
+                "into Nucleus directly from a cloud storage provider. See "
+                "https://dashboard.scale.com/nucleus/docs/api?language=python#guide-for-large-ingestions"
+                " for details."
             )
 
         if asynchronous:

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -30,6 +30,9 @@ from .dataset_item import (
 from .payload_constructor import construct_model_run_creation_payload
 
 
+WARN_FOR_LARGE_UPLOAD = 50000
+
+
 class Dataset:
     """
     Nucleus Dataset. You can append images with metadata to your dataset,
@@ -210,6 +213,11 @@ class Dataset:
         }
         """
         check_for_duplicate_reference_ids(dataset_items)
+
+        if len(dataset_items) > WARN_FOR_LARGE_UPLOAD and not asynchronous:
+            print(
+                "WARNING: for large uploads we recommend uploading your images remotely to a cloud storage provider and then using asynchronous=True."
+            )
 
         if asynchronous:
             check_all_paths_remote(dataset_items)

--- a/nucleus/dataset_item.py
+++ b/nucleus/dataset_item.py
@@ -52,7 +52,7 @@ class DatasetItem:
         return payload
 
     def to_json(self) -> str:
-        return json.dumps(self.to_payload())
+        return json.dumps(self.to_payload(), allow_nan=False)
 
 
 def is_local_path(path: str) -> bool:

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -25,9 +25,23 @@ class DatasetItemRetrievalError(Exception):
 
 
 class NucleusAPIError(Exception):
-    def __init__(self, endpoint, command, response):
-        message = f"Tried to {command.__name__} {endpoint}, but received {response.status_code}: {response.reason}."
-        if hasattr(response, "text"):
-            if response.text:
-                message += f"\nThe detailed error is:\n{response.text}"
+    def __init__(
+        self, endpoint, command, requests_response=None, aiohttp_response=None
+    ):
+
+        if requests_response is not None:
+            message = f"Tried to {command.__name__} {endpoint}, but received {requests_response.status_code}: {requests_response.reason}."
+            if hasattr(requests_response, "text"):
+                if requests_response.text:
+                    message += (
+                        f"\nThe detailed error is:\n{requests_response.text}"
+                    )
+
+        if aiohttp_response is not None:
+            message = f"Tried to {command.__name__} {endpoint}, but received {aiohttp_response.status}: {aiohttp_response.reason}."
+            if hasattr(requests_response, "text"):
+                text = requests_response.text()
+                if text:
+                    message += f"\nThe detailed error is:\n{text}"
+
         super().__init__(message)

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -38,10 +38,9 @@ class NucleusAPIError(Exception):
                     )
 
         if aiohttp_response is not None:
-            message = f"Tried to {command.__name__} {endpoint}, but received {aiohttp_response.status}: {aiohttp_response.reason}."
-            if hasattr(requests_response, "text"):
-                text = requests_response.text()
-                if text:
-                    message += f"\nThe detailed error is:\n{text}"
+            status, reason, data = aiohttp_response
+            message = f"Tried to {command.__name__} {endpoint}, but received {status}: {reason}."
+            if data:
+                message += f"\nThe detailed error is:\n{data}"
 
         super().__init__(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://dashboard.scale.com/nucleus/docs/api"
 packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7.0"
 requests = "^2.25.1"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ python = "^3.6.2"
 requests = "^2.25.1"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
+aiohttp = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-grequests = "^0.6.0"
 requests = "^2.25.1"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ documentation = "https://dashboard.scale.com/nucleus/docs/api"
 packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
-requests = "^2.25.1"
+python = "^3.6.2"
+requests = "^2.23.0"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
 aiohttp = "^3.7.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.1.7"
+version = "0.1.8"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
* Remove grequests as a dependency
* Switch to using aiohttp for local file uploads
* Add warning for large uploads
* Local file uploads will now crash loudly if anything goes wrong on any batch instead of silently proceeding with errors
* Disallow sending NaNs for now since that would mess up querying
* Bump version to prepare for release
* Match all dependency requirements with colab so we stop getting errors when trying to use the client in colab

The default behavior is now for all synchronous API endpoints (local and remote) to crash on any failure, and for asynchronous large batch uploads to proceed but log errors.