### PR TITLE
add cuboid annotations to client

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -559,7 +559,12 @@ class NucleusClient:
         self,
         dataset_id: str,
         annotations: List[
-            Union[BoxAnnotation, PolygonAnnotation, SegmentationAnnotation]
+            Union[
+                BoxAnnotation,
+                PolygonAnnotation,
+                CuboidAnnotation,
+                SegmentationAnnotation,
+            ]
         ],
         update: bool,
         batch_size: int = 5000,
@@ -567,13 +572,10 @@ class NucleusClient:
         """
         Uploads ground truth annotations for a given dataset.
         :param dataset_id: id of the dataset
-        :param annotations: List[Union[BoxAnnotation, PolygonAnnotation]]
+        :param annotations: List[Union[BoxAnnotation, PolygonAnnotation, CuboidAnnotation, SegmentationAnnotation]]
         :param update: whether to update or ignore conflicting annotations
         :return: {"dataset_id: str, "annotations_processed": int}
         """
-        if any((isinstance(ann, CuboidAnnotation) for ann in annotations)):
-            raise NotImplementedError("Cuboid annotations not yet supported")
-
         # Split payload into segmentations and Box/Polygon
         segmentations = [
             ann
@@ -714,14 +716,19 @@ class NucleusClient:
         self,
         model_run_id: str,
         annotations: List[
-            Union[BoxPrediction, PolygonPrediction, SegmentationPrediction]
+            Union[
+                BoxPrediction,
+                PolygonPrediction,
+                CuboidPrediction,
+                SegmentationPrediction,
+            ]
         ],
         update: bool,
         batch_size: int = 5000,
     ):
         """
         Uploads model outputs as predictions for a model_run. Returns info about the upload.
-        :param annotations: List[Union[BoxPrediction, PolygonPrediction]],
+        :param annotations: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         :param update: bool
         :return:
         {
@@ -731,9 +738,6 @@ class NucleusClient:
             "predictions_ignored": int,
         }
         """
-        if any((isinstance(ann, CuboidPrediction) for ann in annotations)):
-            raise NotImplementedError("Cuboid predictions not yet supported")
-
         segmentations = [
             ann
             for ann in annotations
@@ -885,7 +889,7 @@ class NucleusClient:
         :param reference_id: reference_id of a dataset item.
         :return:
         {
-            "annotations": List[BoxPrediction],
+            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         }
         """
         return self.make_request(
@@ -910,7 +914,7 @@ class NucleusClient:
         :param i: absolute number of Dataset Item for a dataset corresponding to the model run.
         :return:
         {
-            "annotations": List[BoxPrediction],
+            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         }
         """
         return self.make_request(
@@ -939,7 +943,7 @@ class NucleusClient:
         :param dataset_item_id: dataset_item_id of a dataset item.
         :return:
         {
-            "annotations": List[BoxPrediction],
+            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         }
         """
         return self.make_request(

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -289,7 +289,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
             dimensions=Point3D.from_json(geometry.get(DIMENSIONS_KEY, {})),
             yaw=payload.get(YAW_KEY, 0),
             reference_id=payload.get(REFERENCE_ID_KEY, None),
-            item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            item_id=payload.get(ITEM_ID_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )
@@ -299,11 +299,12 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
             LABEL_KEY: self.label,
             TYPE_KEY: CUBOID_TYPE,
             GEOMETRY_KEY: {
-                POSITION_KEY: self.position,
-                DIMENSIONS_KEY: self.dimensions,
+                POSITION_KEY: self.position.to_payload(),
+                DIMENSIONS_KEY: self.dimensions.to_payload(),
                 YAW_KEY: self.yaw,
             },
             REFERENCE_ID_KEY: self.reference_id,
+            ITEM_ID_KEY: self.item_id,
             ANNOTATION_ID_KEY: self.annotation_id,
             METADATA_KEY: self.metadata,
         }

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -12,7 +12,6 @@ from nucleus.utils import (
 
 from .annotation import (
     Annotation,
-    CuboidAnnotation,
     check_all_mask_paths_remote,
 )
 from .constants import (

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -12,7 +12,6 @@ from nucleus.utils import (
 
 from .annotation import (
     Annotation,
-    CuboidAnnotation,
     check_all_annotation_paths_remote,
 )
 from .constants import (
@@ -168,9 +167,6 @@ class Dataset:
             "ignored_items": int,
         }
         """
-        if any((isinstance(ann, CuboidAnnotation) for ann in annotations)):
-            raise NotImplementedError("Cuboid annotations not yet supported")
-
         if asynchronous:
             check_all_annotation_paths_remote(annotations)
 
@@ -257,7 +253,7 @@ class Dataset:
         :return:
         {
             "item": DatasetItem,
-            "annotations": List[Union[BoxAnnotation, PolygonAnnotation]],
+            "annotations": List[Union[BoxAnnotation, PolygonAnnotation, CuboidAnnotation, SegmentationAnnotation]],
         }
         """
         response = self._client.dataitem_iloc(self.id, i)
@@ -270,7 +266,7 @@ class Dataset:
         :return:
         {
             "item": DatasetItem,
-            "annotations": List[Union[BoxAnnotation, PolygonAnnotation]],
+            "annotations": List[Union[BoxAnnotation, PolygonAnnotation, CuboidAnnotation, SegmentationAnnotation]],
         }
         """
         response = self._client.dataitem_ref_id(self.id, reference_id)
@@ -283,7 +279,7 @@ class Dataset:
         :return:
         {
             "item": DatasetItem,
-            "annotations": List[Union[BoxAnnotation, PolygonAnnotation]],
+            "annotations": List[Union[BoxAnnotation, PolygonAnnotation, CuboidAnnotation, SegmentationAnnotation]],
         }
         """
         response = self._client.dataitem_loc(self.id, dataset_item_id)

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Dict, Union
 from .dataset import Dataset
 from .prediction import (
     BoxPrediction,
+    CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
 )
@@ -42,7 +43,12 @@ class Model:
         name: str,
         dataset: Dataset,
         predictions: List[
-            Union[BoxPrediction, PolygonPrediction, SegmentationPrediction]
+            Union[
+                BoxPrediction,
+                PolygonPrediction,
+                CuboidPrediction,
+                SegmentationPrediction,
+            ]
         ],
         metadata: Optional[Dict] = None,
         asynchronous: bool = False,

--- a/nucleus/model_run.py
+++ b/nucleus/model_run.py
@@ -7,6 +7,7 @@ from nucleus.utils import serialize_and_write_to_presigned_url
 from .constants import (
     ANNOTATIONS_KEY,
     BOX_TYPE,
+    CUBOID_TYPE,
     DEFAULT_ANNOTATION_UPDATE_MODE,
     JOB_ID_KEY,
     POLYGON_TYPE,
@@ -16,6 +17,7 @@ from .constants import (
 )
 from .prediction import (
     BoxPrediction,
+    CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
 )
@@ -90,14 +92,19 @@ class ModelRun:
     def predict(
         self,
         annotations: List[
-            Union[BoxPrediction, PolygonPrediction, SegmentationPrediction]
+            Union[
+                BoxPrediction,
+                PolygonPrediction,
+                CuboidPrediction,
+                SegmentationPrediction,
+            ]
         ],
         update: Optional[bool] = DEFAULT_ANNOTATION_UPDATE_MODE,
         asynchronous: bool = False,
     ) -> Union[dict, AsyncJob]:
         """
         Uploads model outputs as predictions for a model_run. Returns info about the upload.
-        :param annotations: List[Union[BoxPrediction, PolygonPrediction]],
+        :param annotations: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         :return:
         {
             "model_run_id": str,
@@ -124,7 +131,7 @@ class ModelRun:
         """
         Returns Model Run Info For Dataset Item by its number.
         :param i: absolute number of Dataset Item for a dataset corresponding to the model run.
-        :return: List[Union[BoxPrediction, PolygonPrediction]],
+        :return: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         }
         """
         response = self._client.predictions_iloc(self.model_run_id, i)
@@ -134,7 +141,7 @@ class ModelRun:
         """
         Returns Model Run Info For Dataset Item by its reference_id.
         :param reference_id: reference_id of a dataset item.
-        :return: List[Union[BoxPrediction, PolygonPrediction]],
+        :return: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
         """
         response = self._client.predictions_ref_id(
             self.model_run_id, reference_id
@@ -159,7 +166,14 @@ class ModelRun:
         self, response: dict
     ) -> Union[
         dict,
-        List[Union[BoxPrediction, PolygonPrediction, SegmentationPrediction]],
+        List[
+            Union[
+                BoxPrediction,
+                PolygonPrediction,
+                CuboidPrediction,
+                SegmentationPrediction,
+            ]
+        ],
     ]:
         annotation_payload = response.get(ANNOTATIONS_KEY, None)
         if not annotation_payload:
@@ -171,11 +185,13 @@ class ModelRun:
             Union[
                 Type[BoxPrediction],
                 Type[PolygonPrediction],
+                Type[CuboidPrediction],
                 Type[SegmentationPrediction],
             ],
         ] = {
             BOX_TYPE: BoxPrediction,
             POLYGON_TYPE: PolygonPrediction,
+            CUBOID_TYPE: CuboidPrediction,
             SEGMENTATION_TYPE: SegmentationPrediction,
         }
         for type_key in annotation_payload:

--- a/nucleus/payload_constructor.py
+++ b/nucleus/payload_constructor.py
@@ -2,11 +2,13 @@ from typing import List, Optional, Dict, Union
 from .dataset_item import DatasetItem
 from .annotation import (
     BoxAnnotation,
+    CuboidAnnotation,
     PolygonAnnotation,
     SegmentationAnnotation,
 )
 from .prediction import (
     BoxPrediction,
+    CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
 )
@@ -39,7 +41,14 @@ def construct_append_payload(
 
 
 def construct_annotation_payload(
-    annotation_items: List[Union[BoxAnnotation, PolygonAnnotation]],
+    annotation_items: List[
+        Union[
+            BoxAnnotation,
+            PolygonAnnotation,
+            CuboidAnnotation,
+            SegmentationAnnotation,
+        ]
+    ],
     update: bool,
 ) -> dict:
     annotations = []
@@ -63,7 +72,9 @@ def construct_segmentation_payload(
 
 
 def construct_box_predictions_payload(
-    box_predictions: List[Union[BoxPrediction, PolygonPrediction]],
+    box_predictions: List[
+        Union[BoxPrediction, PolygonPrediction, CuboidPrediction]
+    ],
     update: bool,
 ) -> dict:
     predictions = []

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -198,7 +198,7 @@ class CuboidPrediction(CuboidAnnotation):
             dimensions=Point3D.from_json(geometry.get(DIMENSIONS_KEY, {})),
             yaw=payload.get(YAW_KEY, 0),
             reference_id=payload.get(REFERENCE_ID_KEY, None),
-            item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            item_id=payload.get(ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -11,6 +11,7 @@ from requests.models import HTTPError
 from nucleus.annotation import (
     Annotation,
     BoxAnnotation,
+    CuboidAnnotation,
     PolygonAnnotation,
     SegmentationAnnotation,
 )
@@ -19,13 +20,14 @@ from .constants import (
     ANNOTATION_TYPES,
     ANNOTATIONS_KEY,
     BOX_TYPE,
+    CUBOID_TYPE,
     ITEM_KEY,
     POLYGON_TYPE,
     REFERENCE_ID_KEY,
     SEGMENTATION_TYPE,
 )
 from .dataset_item import DatasetItem
-from .prediction import BoxPrediction, PolygonPrediction
+from .prediction import BoxPrediction, CuboidPrediction, PolygonPrediction
 
 
 def _get_all_field_values(metadata_list: List[dict], key: str):
@@ -34,7 +36,10 @@ def _get_all_field_values(metadata_list: List[dict], key: str):
 
 def suggest_metadata_schema(
     data: Union[
-        List[DatasetItem], List[BoxPrediction], List[PolygonPrediction]
+        List[DatasetItem],
+        List[BoxPrediction],
+        List[PolygonPrediction],
+        List[CuboidPrediction],
     ]
 ):
     metadata_list: List[dict] = [
@@ -106,6 +111,9 @@ def convert_export_payload(api_payload):
         for box in row[BOX_TYPE]:
             box[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             annotations[BOX_TYPE].append(BoxAnnotation.from_json(box))
+        for cuboid in row[CUBOID_TYPE]:
+            cuboid[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            annotations[CUBOID_TYPE].append(CuboidAnnotation.from_json(cuboid))
         return_payload_row[ANNOTATIONS_KEY] = annotations
         return_payload.append(return_payload_row)
     return return_payload

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,7 @@ PRESIGN_EXPIRY_SECONDS = 60 * 60 * 24 * 2  # 2 days
 TEST_MODEL_NAME = "[PyTest] Test Model"
 TEST_MODEL_RUN = "[PyTest] Test Model Run"
 TEST_DATASET_NAME = "[PyTest] Test Dataset"
+TEST_DATASET_3D_NAME = "[PyTest] Test Dataset 3D"
 TEST_SLICE_NAME = "[PyTest] Test Slice"
 TEST_PROJECT_ID = "60b699d70f139e002dd31bfc"
 
@@ -19,6 +20,10 @@ TEST_IMG_URLS = [
     "https://homepages.cae.wisc.edu/~ece533/images/baboon.png",
     "https://homepages.cae.wisc.edu/~ece533/images/barbara.png",
     "https://homepages.cae.wisc.edu/~ece533/images/cat.png",
+]
+
+TEST_POINTCLOUD_URLS = [
+    "https://scale-us-attachments.s3.us-west-2.amazonaws.com/select/examples/kitti_example_frame.json",
 ]
 
 TEST_DATASET_ITEMS = [
@@ -70,6 +75,28 @@ TEST_POLYGON_ANNOTATIONS = [
         "annotation_id": f"[Pytest] Polygon Annotation Annotation Id{i}",
     }
     for i in range(len(TEST_IMG_URLS))
+]
+
+TEST_CUBOID_ANNOTATIONS = [
+    {
+        "label": f"[Pytest] Cuboid Annotation ${i}",
+        "geometry": {
+            "position": {
+                "x": 50 * i + 10,
+                "y": 60 * i + 10,
+                "z": 70 * i + 10,
+            },
+            "dimensions": {
+                "x": 10 * i,
+                "y": 20 * i,
+                "z": 30 * i,
+            },
+            "yaw": 5 * i,
+        },
+        "reference_id": reference_id_from_url(TEST_POINTCLOUD_URLS[i]),
+        "annotation_id": f"[Pytest] Cuboid Annotation Annotation Id{i}",
+    }
+    for i in range(len(TEST_POINTCLOUD_URLS))
 ]
 
 
@@ -155,6 +182,29 @@ def assert_polygon_annotation_matches_dict(
     ):
         assert instance_pt.x == dict_pt["x"]
         assert instance_pt.y == dict_pt["y"]
+
+
+def assert_cuboid_annotation_matches_dict(
+    annotation_instance, annotation_dict
+):
+    assert annotation_instance.label == annotation_dict["label"]
+    assert (
+        annotation_instance.annotation_id == annotation_dict["annotation_id"]
+    )
+    for instance_pt, dict_pt in zip(
+        annotation_instance.position, annotation_dict["geometry"]["position"]
+    ):
+        assert instance_pt.x == dict_pt["x"]
+        assert instance_pt.y == dict_pt["y"]
+        assert instance_pt.z == dict_pt["z"]
+    for instance_pt, dict_pt in zip(
+        annotation_instance.dimensions,
+        annotation_dict["geometry"]["dimensions"],
+    ):
+        assert instance_pt.x == dict_pt["x"]
+        assert instance_pt.y == dict_pt["y"]
+        assert instance_pt.z == dict_pt["z"]
+    assert annotation_instance.yaw == annotation_dict["geometry"]["yaw"]
 
 
 def assert_segmentation_annotation_matches_dict(

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -2,19 +2,24 @@ import pytest
 
 from .helpers import (
     TEST_DATASET_NAME,
+    TEST_DATASET_3D_NAME,
     TEST_IMG_URLS,
+    TEST_POINTCLOUD_URLS,
     TEST_BOX_ANNOTATIONS,
     TEST_POLYGON_ANNOTATIONS,
+    TEST_CUBOID_ANNOTATIONS,
     TEST_SEGMENTATION_ANNOTATIONS,
     reference_id_from_url,
     assert_box_annotation_matches_dict,
     assert_polygon_annotation_matches_dict,
+    assert_cuboid_annotation_matches_dict,
     assert_segmentation_annotation_matches_dict,
 )
 
 from nucleus import (
     BoxAnnotation,
     PolygonAnnotation,
+    CuboidAnnotation,
     SegmentationAnnotation,
     DatasetItem,
     Segment,
@@ -61,6 +66,26 @@ def dataset(CLIENT):
     assert response == {"message": "Beginning dataset deletion..."}
 
 
+@pytest.fixture()
+def dataset_3d(CLIENT):
+    ds = CLIENT.create_dataset(TEST_DATASET_3D_NAME)
+    ds_items = []
+    for url in TEST_POINTCLOUD_URLS:
+        ds_items.append(
+            DatasetItem(
+                image_location=url,
+                reference_id=reference_id_from_url(url),
+            )
+        )
+
+    response = ds.append(ds_items)
+    assert ERROR_PAYLOAD not in response.json()
+    yield ds
+
+    response = CLIENT.delete_dataset(ds.id)
+    assert response == {"message": "Beginning dataset deletion..."}
+
+
 def test_box_gt_upload(dataset):
     annotation = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
     response = dataset.annotate(annotations=[annotation])
@@ -92,6 +117,24 @@ def test_polygon_gt_upload(dataset):
     response_annotation = response[0]
     assert_polygon_annotation_matches_dict(
         response_annotation, TEST_POLYGON_ANNOTATIONS[0]
+    )
+
+
+def test_cuboid_gt_upload(dataset_3d):
+    annotation = CuboidAnnotation.from_json(TEST_CUBOID_ANNOTATIONS[0])
+    response = dataset_3d.annotate(annotations=[annotation])
+
+    assert response["dataset_id"] == dataset_3d.id
+    assert response["annotations_processed"] == 1
+    assert response["annotations_ignored"] == 0
+
+    response = dataset_3d.refloc(annotation.reference_id)["annotations"][
+        "cuboid"
+    ]
+    assert len(response) == 1
+    response_annotation = response[0]
+    assert_cuboid_annotation_matches_dict(
+        response_annotation, TEST_CUBOID_ANNOTATIONS[0]
     )
 
 


### PR DESCRIPTION
This PR adds client side support for CuboidAnnotations and CuboidPredictions. The endpoint for uploading predictions and annotations already supports cuboids, so uploading cuboid annotations and predictions to a dataset from the Python client should work now.

Edit: Backend changes for /exportForTraining have landed

Changed DATASET_ITEM_ID_KEY to ITEM_ID_KEY in annotation/prediction classes since backend expects the field "item_id" to be populated