### PR TITLE
No more null reference ids

### DIFF
--- a/nucleus/dataset_item.py
+++ b/nucleus/dataset_item.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 from .annotation import is_local_path, Point3D
 from .constants import (
-    DATASET_ITEM_ID_KEY,
     IMAGE_URL_KEY,
     METADATA_KEY,
     ORIGINAL_IMAGE_URL_KEY,
@@ -91,11 +90,11 @@ class DatasetItemType(Enum):
 class DatasetItem:  # pylint: disable=R0902
     image_location: Optional[str] = None
     reference_id: Optional[str] = None
-    item_id: Optional[str] = None
     metadata: Optional[dict] = None
     pointcloud_location: Optional[str] = None
 
     def __post_init__(self):
+        assert self.reference_id is not None, "reference_id is required."
         assert bool(self.image_location) != bool(
             self.pointcloud_location
         ), "Must specify exactly one of the image_location, pointcloud_location parameters"
@@ -127,14 +126,12 @@ class DatasetItem:  # pylint: disable=R0902
                 image_location=image_url,
                 pointcloud_location=payload.get(POINTCLOUD_URL_KEY, None),
                 reference_id=payload.get(REFERENCE_ID_KEY, None),
-                item_id=payload.get(DATASET_ITEM_ID_KEY, None),
                 metadata=payload.get(METADATA_KEY, {}),
             )
 
         return cls(
             image_location=image_url,
             reference_id=payload.get(REFERENCE_ID_KEY, None),
-            item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )
 
@@ -145,10 +142,8 @@ class DatasetItem:  # pylint: disable=R0902
         payload: Dict[str, Any] = {
             METADATA_KEY: self.metadata or {},
         }
-        if self.reference_id:
-            payload[REFERENCE_ID_KEY] = self.reference_id
-        if self.item_id:
-            payload[DATASET_ITEM_ID_KEY] = self.item_id
+
+        payload[REFERENCE_ID_KEY] = self.reference_id
 
         if is_scene:
             if self.image_location:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -177,7 +177,11 @@ def test_dataset_append(dataset):
     # Plain image upload
     ds_items_plain = []
     for url in TEST_IMG_URLS:
-        ds_items_plain.append(DatasetItem(image_location=url))
+        ds_items_plain.append(
+            DatasetItem(
+                image_location=url, reference_id=url.split("/")[-1] + "_plain"
+            )
+        )
     response = dataset.append(ds_items_plain)
     check_is_expected_response(response)
 
@@ -189,7 +193,11 @@ def test_dataset_append(dataset):
 
 def test_dataset_append_local(CLIENT, dataset):
     ds_items_local_error = [
-        DatasetItem(image_location=LOCAL_FILENAME, metadata={"test": math.nan})
+        DatasetItem(
+            image_location=LOCAL_FILENAME,
+            metadata={"test": math.nan},
+            reference_id="bad",
+        )
     ]
     with pytest.raises(ValueError) as e:
         dataset.append(ds_items_local_error)
@@ -197,7 +205,11 @@ def test_dataset_append_local(CLIENT, dataset):
             e.value
         )
     ds_items_local = [
-        DatasetItem(image_location=LOCAL_FILENAME, metadata={"test": 0})
+        DatasetItem(
+            image_location=LOCAL_FILENAME,
+            metadata={"test": 0},
+            reference_id=LOCAL_FILENAME.split("/")[-1],
+        )
     ]
 
     response = dataset.append(ds_items_local)


### PR DESCRIPTION
Disallow python client from sending invalid requests: we no longer use dataset item id in append, and require reference id.