### PR TITLE
Update custom indexing integration test to sleep until the job is complete

### DIFF
--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -52,6 +52,9 @@ def test_index_integration(dataset):
     assert JOB_ID_KEY in job_status_response
     assert MESSAGE_KEY in job_status_response
 
+    job.sleep_until_complete()
+    assert job.job_last_known_status == "Completed"
+
 
 @pytest.mark.skip(reason="Times out consistently")
 def test_generate_image_index_integration(dataset):


### PR DESCRIPTION
Otherwise, the dataset gets completed before the job is finished and results in errors being reported on our side.