### PR TITLE
Category Prediction

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -87,6 +87,7 @@ from .prediction import (
     CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
+    CategoryPrediction,
 )
 from .scene import Frame, LidarScene
 from .slice import Slice
@@ -742,6 +743,7 @@ class NucleusClient:
                 PolygonPrediction,
                 CuboidPrediction,
                 SegmentationPrediction,
+                CategoryPrediction,
             ]
         ],
         model_run_id: Optional[str] = None,
@@ -752,7 +754,7 @@ class NucleusClient:
     ):
         """
         Uploads model outputs as predictions for a model_run. Returns info about the upload.
-        :param annotations: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
+        :param annotations: List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction, CategoryPrediction]],
         :param update: bool
         :return:
         {
@@ -914,7 +916,7 @@ class NucleusClient:
         :param reference_id: reference_id of a dataset item.
         :return:
         {
-            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
+            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction, CategoryPrediction]],
         }
         """
         return self.make_request(
@@ -939,7 +941,7 @@ class NucleusClient:
         :param i: absolute number of Dataset Item for a dataset corresponding to the model run.
         :return:
         {
-            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction]],
+            "annotations": List[Union[BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction, CategoryPrediction]],
         }
         """
         return self.make_request(

--- a/nucleus/payload_constructor.py
+++ b/nucleus/payload_constructor.py
@@ -14,6 +14,7 @@ from .prediction import (
     CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
+    CategoryPrediction,
 )
 from .constants import (
     ANNOTATION_UPDATE_KEY,
@@ -91,7 +92,12 @@ def construct_segmentation_payload(
 
 def construct_box_predictions_payload(
     box_predictions: List[
-        Union[BoxPrediction, PolygonPrediction, CuboidPrediction]
+        Union[
+            BoxPrediction,
+            PolygonPrediction,
+            CuboidPrediction,
+            CategoryPrediction,
+        ]
     ],
     update: bool,
 ) -> dict:

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional, List
 from .annotation import (
     BoxAnnotation,
+    CategoryAnnotation,
     Point,
     PolygonAnnotation,
     Segment,
@@ -13,10 +14,12 @@ from .constants import (
     BOX_TYPE,
     CUBOID_TYPE,
     POLYGON_TYPE,
+    CATEGORY_TYPE,
     REFERENCE_ID_KEY,
     METADATA_KEY,
     GEOMETRY_KEY,
     LABEL_KEY,
+    TAXONOMY_NAME_KEY,
     TYPE_KEY,
     X_KEY,
     Y_KEY,
@@ -40,6 +43,8 @@ def from_json(payload: dict):
         return PolygonPrediction.from_json(payload)
     elif payload.get(TYPE_KEY, None) == CUBOID_TYPE:
         return CuboidPrediction.from_json(payload)
+    elif payload.get(TYPE_KEY, None) == CATEGORY_TYPE:
+        return CategoryPrediction.from_json(payload)
     else:
         return SegmentationPrediction.from_json(payload)
 
@@ -204,6 +209,46 @@ class CuboidPrediction(CuboidAnnotation):
             reference_id=payload[REFERENCE_ID_KEY],
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
+            metadata=payload.get(METADATA_KEY, {}),
+            class_pdf=payload.get(CLASS_PDF_KEY, None),
+        )
+
+
+class CategoryPrediction(CategoryAnnotation):
+    def __init__(
+        self,
+        label: str,
+        taxonomy_name: str,
+        reference_id: str,
+        confidence: Optional[float] = None,
+        metadata: Optional[Dict] = None,
+        class_pdf: Optional[Dict] = None,
+    ):
+        super().__init__(
+            label=label,
+            taxonomy_name=taxonomy_name,
+            reference_id=reference_id,
+            metadata=metadata,
+        )
+        self.confidence = confidence
+        self.class_pdf = class_pdf
+
+    def to_payload(self) -> dict:
+        payload = super().to_payload()
+        if self.confidence is not None:
+            payload[CONFIDENCE_KEY] = self.confidence
+        if self.class_pdf is not None:
+            payload[CLASS_PDF_KEY] = self.class_pdf
+
+        return payload
+
+    @classmethod
+    def from_json(cls, payload: dict):
+        return cls(
+            label=payload.get(LABEL_KEY, 0),
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
+            reference_id=payload[REFERENCE_ID_KEY],
+            confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
         )

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -34,6 +34,7 @@ from .constants import (
 from .dataset_item import DatasetItem
 from .prediction import (
     BoxPrediction,
+    CategoryPrediction,
     CuboidPrediction,
     PolygonPrediction,
     SegmentationPrediction,
@@ -50,6 +51,7 @@ def format_prediction_response(
             BoxPrediction,
             PolygonPrediction,
             CuboidPrediction,
+            CategoryPrediction,
             SegmentationPrediction,
         ]
     ],
@@ -65,12 +67,14 @@ def format_prediction_response(
             Type[BoxPrediction],
             Type[PolygonPrediction],
             Type[CuboidPrediction],
+            Type[CategoryPrediction],
             Type[SegmentationPrediction],
         ],
     ] = {
         BOX_TYPE: BoxPrediction,
         POLYGON_TYPE: PolygonPrediction,
         CUBOID_TYPE: CuboidPrediction,
+        CATEGORY_TYPE: CategoryPrediction,
         SEGMENTATION_TYPE: SegmentationPrediction,
     }
     for type_key in annotation_payload:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -206,6 +206,11 @@ TEST_POLYGON_MODEL_PDF = {
     for polygon_annotation in TEST_POLYGON_ANNOTATIONS
 }
 
+TEST_CATEGORY_MODEL_PDF = {
+    category_annotation["label"]: 1 / len(TEST_CATEGORY_ANNOTATIONS)
+    for category_annotation in TEST_CATEGORY_ANNOTATIONS
+}
+
 TEST_BOX_PREDICTIONS = [
     {
         **TEST_BOX_ANNOTATIONS[i],
@@ -232,6 +237,20 @@ TEST_POLYGON_PREDICTIONS = [
         "confidence": 0.10 * i,
     }
     for i in range(len(TEST_POLYGON_ANNOTATIONS))
+]
+
+TEST_CATEGORY_PREDICTIONS = [
+    {
+        **TEST_CATEGORY_ANNOTATIONS[i],
+        "confidence": 0.10 * i,
+        "class_pdf": TEST_CATEGORY_MODEL_PDF,
+    }
+    if i != 0
+    else {
+        **TEST_CATEGORY_ANNOTATIONS[i],
+        "confidence": 0.10 * i,
+    }
+    for i in range(len(TEST_CATEGORY_ANNOTATIONS))
 ]
 
 TEST_INDEX_EMBEDDINGS_FILE = "https://raw.githubusercontent.com/scaleapi/nucleus-python-client/master/tests/testdata/pytest_embeddings_payload.json"
@@ -336,6 +355,15 @@ def assert_polygon_prediction_matches_dict(
     prediction_instance, prediction_dict
 ):
     assert_polygon_annotation_matches_dict(
+        prediction_instance, prediction_dict
+    )
+    assert prediction_instance.confidence == prediction_dict["confidence"]
+
+
+def assert_category_prediction_matches_dict(
+    prediction_instance, prediction_dict
+):
+    assert_category_annotation_matches_dict(
         prediction_instance, prediction_dict
     )
     assert prediction_instance.confidence == prediction_dict["confidence"]

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -10,16 +10,19 @@ from .helpers import (
     TEST_BOX_PREDICTIONS,
     TEST_POLYGON_PREDICTIONS,
     TEST_SEGMENTATION_PREDICTIONS,
+    TEST_CATEGORY_PREDICTIONS,
     reference_id_from_url,
     assert_box_prediction_matches_dict,
     assert_polygon_prediction_matches_dict,
     assert_segmentation_annotation_matches_dict,
+    assert_category_prediction_matches_dict,
 )
 
 from nucleus import (
     BoxPrediction,
     PolygonPrediction,
     SegmentationPrediction,
+    CategoryPrediction,
     DatasetItem,
     ModelRun,
     Segment,
@@ -44,6 +47,11 @@ def test_reprs():
         for _ in TEST_POLYGON_PREDICTIONS
     ]
 
+    [
+        test_repr(CategoryPrediction.from_json(_))
+        for _ in TEST_CATEGORY_PREDICTIONS
+    ]
+
 
 @pytest.fixture()
 def model_run(CLIENT):
@@ -60,6 +68,12 @@ def model_run(CLIENT):
     response = ds.append(ds_items)
 
     assert ERROR_PAYLOAD not in response.json()
+
+    response = ds.add_taxonomy(
+        "[Pytest] Category Taxonomy 1",
+        "category",
+        [f"[Pytest] Category Label ${i}" for i in range((len(TEST_IMG_URLS)))],
+    )
 
     model = CLIENT.add_model(
         name=TEST_MODEL_NAME, reference_id="model_" + str(time.time())
@@ -78,7 +92,7 @@ def model_run(CLIENT):
 def test_box_pred_upload(model_run):
     prediction = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
     response = model_run.predict(annotations=[prediction])
-
+    print(response)
     assert response["model_run_id"] == model_run.model_run_id
     assert response["predictions_processed"] == 1
     assert response["predictions_ignored"] == 0
@@ -104,6 +118,21 @@ def test_polygon_pred_upload(model_run):
     assert len(response) == 1
     assert_polygon_prediction_matches_dict(
         response[0], TEST_POLYGON_PREDICTIONS[0]
+    )
+
+
+def test_category_pred_upload(model_run):
+    prediction = CategoryPrediction.from_json(TEST_CATEGORY_PREDICTIONS[0])
+    response = model_run.predict(annotations=[prediction])
+
+    assert response["model_run_id"] == model_run.model_run_id
+    assert response["predictions_ignored"] == 0
+    assert response["predictions_ignored"] == 0
+
+    response = model_run.refloc(prediction.reference_id)["category"]
+    assert len(response) == 1
+    assert_category_prediction_matches_dict(
+        response[0], TEST_CATEGORY_PREDICTIONS[0]
     )
 
 
@@ -249,6 +278,63 @@ def test_polygon_pred_upload_ignore(model_run):
     )
 
 
+def test_category_pred_upload_update(model_run):
+    prediction = CategoryPrediction.from_json(TEST_CATEGORY_PREDICTIONS[0])
+    response = model_run.predict(annotations=[prediction])
+
+    assert response["predictions_processed"] == 1
+
+    # Copy so we don't modify the original.
+    prediction_update_params = dict(TEST_CATEGORY_PREDICTIONS[1])
+    prediction_update_params["annotation_id"] = TEST_CATEGORY_PREDICTIONS[0][
+        "taxonomy_name"
+    ]
+    prediction_update_params["reference_id"] = TEST_CATEGORY_PREDICTIONS[0][
+        "reference_id"
+    ]
+
+    prediction_update = CategoryPrediction.from_json(prediction_update_params)
+    response = model_run.predict(annotations=[prediction_update], update=True)
+
+    assert response["predictions_processed"] == 1
+    assert response["predictions_ignored"] == 0
+
+    response = model_run.refloc(prediction.reference_id)["category"]
+    assert len(response) == 1
+    assert_category_prediction_matches_dict(
+        response[0], prediction_update_params
+    )
+
+
+def test_category_pred_upload_ignore(model_run):
+    prediction = CategoryPrediction.from_json(TEST_CATEGORY_PREDICTIONS[0])
+    response = model_run.predict(annotations=[prediction])
+
+    assert response["predictions_processed"] == 1
+
+    # Copy so we don't modify the original.
+    prediction_update_params = dict(TEST_CATEGORY_PREDICTIONS[1])
+    prediction_update_params["annotation_id"] = TEST_CATEGORY_PREDICTIONS[0][
+        "taxonomy_name"
+    ]
+    prediction_update_params["reference_id"] = TEST_CATEGORY_PREDICTIONS[0][
+        "reference_id"
+    ]
+
+    prediction_update = CategoryPrediction.from_json(prediction_update_params)
+    # Default behavior is ignore.
+    response = model_run.predict(annotations=[prediction_update])
+
+    assert response["predictions_processed"] == 0
+    assert response["predictions_ignored"] == 1
+
+    response = model_run.refloc(prediction.reference_id)["category"]
+    assert len(response) == 1
+    assert_category_prediction_matches_dict(
+        response[0], TEST_CATEGORY_PREDICTIONS[0]
+    )
+
+
 def test_mixed_pred_upload(model_run: ModelRun):
     prediction_semseg = SegmentationPrediction.from_json(
         TEST_SEGMENTATION_PREDICTIONS[0]
@@ -256,13 +342,21 @@ def test_mixed_pred_upload(model_run: ModelRun):
     prediction_polygon = PolygonPrediction.from_json(
         TEST_POLYGON_PREDICTIONS[0]
     )
+    prediction_category = CategoryPrediction.from_json(
+        TEST_CATEGORY_PREDICTIONS[0]
+    )
     prediction_bbox = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
     response = model_run.predict(
-        annotations=[prediction_semseg, prediction_polygon, prediction_bbox]
+        annotations=[
+            prediction_semseg,
+            prediction_polygon,
+            prediction_category,
+            prediction_bbox,
+        ]
     )
 
     assert response["model_run_id"] == model_run.model_run_id
-    assert response["predictions_processed"] == 3
+    assert response["predictions_processed"] == 4
     assert response["predictions_ignored"] == 0
 
     all_predictions = model_run.ungrouped_export()
@@ -275,6 +369,9 @@ def test_mixed_pred_upload(model_run: ModelRun):
     assert_segmentation_annotation_matches_dict(
         all_predictions["segmentation"][0], TEST_SEGMENTATION_PREDICTIONS[0]
     )
+    assert_category_prediction_matches_dict(
+        all_predictions["category"][0], TEST_CATEGORY_PREDICTIONS[0]
+    )
 
 
 @pytest.mark.integration
@@ -285,12 +382,21 @@ def test_mixed_pred_upload_async(model_run: ModelRun):
     prediction_polygon = PolygonPrediction.from_json(
         TEST_POLYGON_PREDICTIONS[0]
     )
+    prediction_category = CategoryPrediction.from_json(
+        TEST_CATEGORY_PREDICTIONS[0]
+    )
     prediction_bbox = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
     job: AsyncJob = model_run.predict(
-        annotations=[prediction_semseg, prediction_polygon, prediction_bbox],
+        annotations=[
+            prediction_semseg,
+            prediction_polygon,
+            prediction_category,
+            prediction_bbox,
+        ],
         asynchronous=True,
     )
     job.sleep_until_complete()
+    print(job.status())
 
     assert job.status() == {
         "job_id": job.job_id,
@@ -298,11 +404,11 @@ def test_mixed_pred_upload_async(model_run: ModelRun):
         "message": {
             "prediction_upload": {
                 "epoch": 1,
-                "total": 2,
+                "total": 3,
                 "errored": 0,
                 "ignored": 0,
                 "datasetId": model_run.dataset_id,
-                "processed": 2,
+                "processed": 3,
             },
             "segmentation_upload": {
                 "ignored": 0,
@@ -311,8 +417,8 @@ def test_mixed_pred_upload_async(model_run: ModelRun):
             },
         },
         "job_progress": "1.00",
-        "completed_steps": 3,
-        "total_steps": 3,
+        "completed_steps": 4,
+        "total_steps": 4,
     }
 
 
@@ -324,11 +430,19 @@ def test_mixed_pred_upload_async_with_error(model_run: ModelRun):
     prediction_polygon = PolygonPrediction.from_json(
         TEST_POLYGON_PREDICTIONS[0]
     )
+    prediction_category = CategoryPrediction.from_json(
+        TEST_CATEGORY_PREDICTIONS[0]
+    )
     prediction_bbox = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
     prediction_bbox.reference_id = "fake_garbage"
 
     job: AsyncJob = model_run.predict(
-        annotations=[prediction_semseg, prediction_polygon, prediction_bbox],
+        annotations=[
+            prediction_semseg,
+            prediction_polygon,
+            prediction_category,
+            prediction_bbox,
+        ],
         asynchronous=True,
     )
     job.sleep_until_complete()
@@ -339,11 +453,11 @@ def test_mixed_pred_upload_async_with_error(model_run: ModelRun):
         "message": {
             "prediction_upload": {
                 "epoch": 1,
-                "total": 2,
+                "total": 3,
                 "errored": 1,
                 "ignored": 0,
                 "datasetId": model_run.dataset_id,
-                "processed": 1,
+                "processed": 2,
             },
             "segmentation_upload": {
                 "ignored": 0,
@@ -352,8 +466,8 @@ def test_mixed_pred_upload_async_with_error(model_run: ModelRun):
             },
         },
         "job_progress": "1.00",
-        "completed_steps": 3,
-        "total_steps": 3,
+        "completed_steps": 4,
+        "total_steps": 4,
     }
 
     assert "Item with id fake_garbage doesn" in str(job.errors())

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -92,7 +92,7 @@ def model_run(CLIENT):
 def test_box_pred_upload(model_run):
     prediction = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
     response = model_run.predict(annotations=[prediction])
-    print(response)
+
     assert response["model_run_id"] == model_run.model_run_id
     assert response["predictions_processed"] == 1
     assert response["predictions_ignored"] == 0
@@ -396,7 +396,6 @@ def test_mixed_pred_upload_async(model_run: ModelRun):
         asynchronous=True,
     )
     job.sleep_until_complete()
-    print(job.status())
 
     assert job.status() == {
         "job_id": job.job_id,


### PR DESCRIPTION
Added functionality for adding new ground truth category predictions. Unit tests included in PR and tested with code in scaleapi/scaleapi#31481.

## Shortcut Ticket

[[sc-181741]](https://app.shortcut.com/scaleai/story/181741)