### PR TITLE
Add object indexing support

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1180,7 +1180,8 @@ class NucleusClient:
     def create_image_index(self, dataset_id: str):
         """
         Starts generating embeddings for images that don't have embeddings in a given dataset. These embeddings will
-        be used for autotag and similarity search. This endpoint is currently only enabled for enterprise customers.
+        be used for autotag and similarity search. This endpoint is limited to generating embeddings for 5 million
+        images at a time. This endpoint is also currently only enabled for enterprise customers.
         Please reach out to nucleus@scale.com if you wish to learn more.
 
         :param
@@ -1189,6 +1190,28 @@ class NucleusClient:
         return self.make_request(
             {},
             f"indexing/{dataset_id}/internal/image",
+            requests_command=requests.post,
+        )
+
+    def create_object_index(
+        self, dataset_id: str, model_run_id: str, gt_only: bool
+    ):
+        """
+        Starts generating embeddings for objects that don't have embeddings in a given dataset. These embeddings will
+        be used for autotag and similarity search. This endpoint only supports indexing objects sourced from the predictions
+        of a single model run or the ground truth annotations of a dataset.
+
+        This endpoint is limited to generating embeddings for 3 million objects at a time. This endpoint is also currently
+        only enabled for enterprise customers. Please reach out to nucleus@scale.com if you wish to learn more.
+
+        :param
+        dataset_id: id of dataset for generating embeddings on.
+        model_run_id: id of the model run for generating embeddings on. Mutually exclusive with gt_only
+        gt_only: Whether we are generating embeddings on the ground truth objects in a dataset. Mutually exclusive with model_run_id
+        """
+        return self.make_request(
+            {model_run_id: model_run_id or None, gt_only: gt_only or None},
+            f"indexing/{dataset_id}/internal/object",
             requests_command=requests.post,
         )
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1209,8 +1209,13 @@ class NucleusClient:
         model_run_id: id of the model run for generating embeddings on. Mutually exclusive with gt_only
         gt_only: Whether we are generating embeddings on the ground truth objects in a dataset. Mutually exclusive with model_run_id
         """
+        payload: Dict[str, Union[str, bool]] = {}
+        if model_run_id:
+            payload["model_run_id"] = model_run_id
+        elif gt_only:
+            payload["ingest_gt_only"] = True
         return self.make_request(
-            {model_run_id: model_run_id or None, gt_only: gt_only or None},
+            payload,
             f"indexing/{dataset_id}/internal/object",
             requests_command=requests.post,
         )

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -323,7 +323,7 @@ class NucleusClient:
         self,
         dataset_id: str,
         dataset_items: List[DatasetItem],
-        batch_size: int = 100,
+        batch_size: int = 30,
         update: bool = False,
     ):
         """

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1180,7 +1180,7 @@ class NucleusClient:
     def create_image_index(self, dataset_id: str):
         """
         Starts generating embeddings for images that don't have embeddings in a given dataset. These embeddings will
-        be used for autotag and similarity search. This endpoint is limited to generating embeddings for 5 million
+        be used for autotag and similarity search. This endpoint is limited to generating embeddings for 2 million
         images at a time. This endpoint is also currently only enabled for enterprise customers.
         Please reach out to nucleus@scale.com if you wish to learn more.
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -453,6 +453,14 @@ class Dataset:
         response = self._client.create_image_index(self.id)
         return AsyncJob.from_json(response, self._client)
 
+    def create_object_index(
+        self, model_run_id: str = None, gt_only: bool = None
+    ):
+        response = self._client.create_object_index(
+            self.id, model_run_id, gt_only
+        )
+        return AsyncJob.from_json(response, self._client)
+
     def add_taxonomy(
         self,
         taxonomy_name: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.1.24"
+version = "0.1.25"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Need to wait until we merge and deploy our backend with the new changes before tests will pass here. In the meantime, we can test by pointing the python client to our local/devbox backend