### PR TITLE
[docs] add napoleon ext for sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ release = "v" + str(__version__)
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Napoleon is an extension that allows Sphinx to parse Google-style docstrings