### PR TITLE
[docs] document client-facing members only

### DIFF
--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ objname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -4,9 +4,8 @@
 
 .. autoclass:: {{ name }}
    :members:
-   {% block methods %}
-   .. automethod:: __init__
 
+   {% block methods %}
    {% if methods %}
    .. rubric:: {{ _('Methods') }}
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,9 +1,30 @@
-{{ objname | escape | underline}}
+{{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
-.. autoclass:: {{ objname }}
+.. autoclass:: {{ name }}
    :members:
-   :undoc-members:
-   :show-inheritance:
-   :inherited-members:
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in methods %}
+      ~{{ fullname }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -27,39 +27,3 @@
    {%- endfor %}
    {% endif %}
    {% endblock %}
-
-   {% block classes %}
-   {% if classes %}
-   .. rubric:: {{ _('Classes') }}
-
-   .. autosummary::
-      :toctree:
-   {% for item in classes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block exceptions %}
-   {% if exceptions %}
-   .. rubric:: {{ _('Exceptions') }}
-
-   .. autoexception::
-   {% for item in exceptions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-{% block modules %}
-{% if modules %}
-.. rubric:: Modules
-   
-.. autosummary::
-   :toctree:
-   :recursive:
-{% for item in modules %}
-   {{ item }}
-{%- endfor %}
-{% endif %}
-{% endblock %}

--- a/docs/_templates/nucleus-module.rst
+++ b/docs/_templates/nucleus-module.rst
@@ -1,8 +1,6 @@
 {{ objname | escape | underline }}
 
 .. automodule:: {{ fullname }}
-   :imported-members:
-
    {% if classes %}
    .. rubric:: {{ _('Classes') }}
 

--- a/docs/_templates/nucleus-module.rst
+++ b/docs/_templates/nucleus-module.rst
@@ -1,64 +1,15 @@
 {{ objname | escape | underline }}
 
 .. automodule:: {{ fullname }}
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :inherited-members:
-  
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Module Attributes
+   :imported-members:
 
-   .. autoattribute::
-   {% for item in attributes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block functions %}
-   {% if functions %}
-   .. rubric:: {{ _('Functions') }}
-
-   .. autofunction::
-   {% for item in functions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block classes %}
    {% if classes %}
    .. rubric:: {{ _('Classes') }}
 
-   .. autoclass::
+   .. autosummary::
+      :toctree:
+      :recursive:
    {% for item in classes %}
       {{ item }}
    {%- endfor %}
    {% endif %}
-   {% endblock %}
-
-   {% block exceptions %}
-   {% if exceptions %}
-   .. rubric:: {{ _('Exceptions') }}
-
-   .. autoexception::
-   {% for item in exceptions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-{% block modules %}
-{% if modules %}
-.. rubric:: Modules
-   
-.. autosummary::
-   :toctree:
-   :recursive:
-{% for item in modules %}
-   {{ item }}
-{%- endfor %}
-{% endif %}
-{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,3 +61,4 @@ html_theme = "furo"
 html_static_path = ["_static"]
 
 autosummary_generate = True
+autosummary_imported_members = True


### PR DESCRIPTION
Adjust Sphinx `toctree` to only document client-facing members imported to `nucleus/__init__.py`.

current docs (module-based): https://scale-nucleus.readthedocs.io/en/latest/
new docs (import-based): https://scale-nucleus.readthedocs.io/en/drake-sphinx-templates