### PR TITLE
[Model CI] Update and add test for unit test evaluation

### DIFF
--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -180,7 +180,6 @@ class Model:
             model.evaluate(["sample_unit_test"])
 
         Args:
-            model_id: ID of model to evaluate
             unit_test_names: list of unit tests to evaluate
 
         Returns:

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -59,6 +59,8 @@ Note that you can always add more predictions to a dataset, but then you will ne
     dataset.calculate_evaluation_metrics(model)
 """
 from typing import List, Optional, Dict, Union
+
+from nucleus.job import AsyncJob
 from .dataset import Dataset
 from .prediction import (
     BoxPrediction,
@@ -164,3 +166,29 @@ class Model:
         model_run.predict(predictions, asynchronous=asynchronous)
 
         return model_run
+
+    def evaluate(self, unit_test_names: List[str]) -> AsyncJob:
+        """Evaluates this on the specified Unit Tests. ::
+
+            import nucleus.modelci as nm
+            client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
+            model = client.list_models()[0]
+            unit_test = client.modelci.create_unit_test(
+                "sample_unit_test", "slc_bx86ea222a6g057x4380"
+            )
+
+            client.modelci.evaluate_model_on_unit_tests(
+                model_id=model.id,
+                unit_test_names=["sample_unit_test"],
+            )
+
+        Args:
+            model_id: ID of model to evaluate
+            unit_test_names: list of unit tests to evaluate
+
+        Returns:
+            AsyncJob object of evaluation job
+        """
+        return self._client.modelci.evaluate_model_on_unit_tests(
+            self.id, unit_test_names
+        )

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -177,10 +177,7 @@ class Model:
                 "sample_unit_test", "slc_bx86ea222a6g057x4380"
             )
 
-            client.modelci.evaluate_model_on_unit_tests(
-                model_id=model.id,
-                unit_test_names=["sample_unit_test"],
-            )
+            model.evaluate(["sample_unit_test"])
 
         Args:
             model_id: ID of model to evaluate

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -170,7 +170,7 @@ class Model:
     def evaluate(self, unit_test_names: List[str]) -> AsyncJob:
         """Evaluates this on the specified Unit Tests. ::
 
-            import nucleus.modelci as nm
+            import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             model = client.list_models()[0]
             unit_test = client.modelci.create_unit_test(

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -51,10 +51,10 @@ class ModelCI:
     def list_eval_functions(self) -> List[EvalFunction]:
         """List all available evaluation functions. ::
 
-        import nucleus
-        client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
+            import nucleus
+            client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
 
-        eval_functions = client.modelci.list_eval_functions()
+            eval_functions = client.modelci.list_eval_functions()
         """
         response = self._connection.make_request(
             {},

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -33,6 +33,7 @@ from .utils import format_unit_test_eval_response
 
 SUCCESS_KEY = "success"
 EVALUATIONS_KEY = "evaluations"
+EVAL_FUNCTIONS_KEY = "eval_functions"
 
 
 class ModelCI:
@@ -47,7 +48,7 @@ class ModelCI:
     def __eq__(self, other):
         return self._connection == other._connection
 
-    def list_eval_functions(self):
+    def list_eval_functions(self) -> List[EvalFunction]:
         """List all available evaluation functions. ::
 
         import nucleus
@@ -60,7 +61,10 @@ class ModelCI:
             "modelci/eval_fn",
             requests_command=requests.get,
         )
-        return EvalFunction(**response["eval_functions"])
+        return [
+            EvalFunction(**eval_function)
+            for eval_function in response[EVAL_FUNCTIONS_KEY]
+        ]
 
     def create_unit_test(self, name: str, slice_id: str) -> UnitTest:
         """Creates a new Unit Test. ::
@@ -280,7 +284,7 @@ class ModelCI:
             requests_command=requests.get,
         )
         return [
-            UnitTestEvaluation(**eval[ID_KEY])
+            self.get_unit_test_eval_info(eval[ID_KEY])
             for eval in response[EVALUATIONS_KEY]
         ]
 

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -162,7 +162,6 @@ class ModelCI:
         """Lists all Unit Tests of the current user. ::
 
             import nucleus
-            from nucleus.modelci.unit_test import ThresholdComparison
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             unit_test = client.modelci.create_unit_test(
                 "sample_unit_test", "slc_bx86ea222a6g057x4380"
@@ -185,7 +184,7 @@ class ModelCI:
     def get_unit_test_metrics(self, unit_test_id: str) -> List[UnitTestMetric]:
         """Retrieves all metrics of the Unit Test. ::
 
-            import nucleus.modelci as nm
+            import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             unit_test = client.modelci.list_unit_tests()[0]
 
@@ -211,7 +210,6 @@ class ModelCI:
         """Creates a new Unit Test. ::
 
             import nucleus
-            from nucleus.modelci.unit_test import ThresholdComparison
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             unit_test = client.modelci.list_unit_tests()[0]
 
@@ -235,7 +233,7 @@ class ModelCI:
     ) -> AsyncJob:
         """Evaluates the given model on the specified Unit Tests. ::
 
-            import nucleus.modelci as nm
+            import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             model = client.list_models()[0]
             unit_test = client.modelci.create_unit_test(

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -51,10 +51,10 @@ class ModelCI:
     def list_eval_functions(self) -> List[EvalFunction]:
         """List all available evaluation functions. ::
 
-            import nucleus
-            client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
+        import nucleus
+        client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
 
-            eval_functions = client.modelci.list_eval_functions()
+        eval_functions = client.modelci.list_eval_functions()
         """
         response = self._connection.make_request(
             {},

--- a/nucleus/modelci/eval_function.py
+++ b/nucleus/modelci/eval_function.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 class EvalFunction:
     """Encapsulates an evaluation function for Model CI."""
 
+    id: str
     name: str
     user_id: str
     serialized_fn: str

--- a/nucleus/modelci/unit_test.py
+++ b/nucleus/modelci/unit_test.py
@@ -34,7 +34,7 @@ class UnitTestMetric:
     unit_test_id: str
     eval_function_id: str
     threshold: float
-    threshold_comparison: str
+    threshold_comparison: ThresholdComparison
 
 
 class UnitTest:

--- a/nucleus/modelci/utils.py
+++ b/nucleus/modelci/utils.py
@@ -21,7 +21,7 @@ def format_unit_test_item_eval_response(
         evaluation_id=response["evaluation_id"],
         unit_test_id=response["unit_test_id"],
         eval_function_id=response["eval_function_id"],
-        dataset_item_id=response["model_id"],
+        dataset_item_id=response["dataset_item_id"],
         result=try_convert_float(response["result"]),
         passed=bool(response["pass"]),
     )

--- a/tests/modelci/test_eval_function.py
+++ b/tests/modelci/test_eval_function.py
@@ -1,0 +1,5 @@
+from nucleus.modelci.eval_function import EvalFunction
+
+def test_list_eval_functions(CLIENT):
+    eval_functions = CLIENT.modelci.list_eval_functions()
+    assert all(isinstance(eval_fn, EvalFunction) for eval_fn in eval_functions)

--- a/tests/modelci/test_eval_function.py
+++ b/tests/modelci/test_eval_function.py
@@ -1,5 +1,6 @@
 from nucleus.modelci.eval_function import EvalFunction
 
+
 def test_list_eval_functions(CLIENT):
     eval_functions = CLIENT.modelci.list_eval_functions()
     assert all(isinstance(eval_fn, EvalFunction) for eval_fn in eval_functions)

--- a/tests/modelci/test_unit_test.py
+++ b/tests/modelci/test_unit_test.py
@@ -64,5 +64,4 @@ def test_list_unit_test(CLIENT, dataset):
 
     unit_tests = CLIENT.modelci.list_unit_tests()
     assert all(isinstance(unit_test, UnitTest) for unit_test in unit_tests)
-    assert len(unit_tests) == 1
-    assert unit_test.__dict__ == unit_tests[0].__dict__
+    assert unit_test in unit_tests

--- a/tests/modelci/test_unit_test_evaluation.py
+++ b/tests/modelci/test_unit_test_evaluation.py
@@ -1,0 +1,55 @@
+import pytest
+import uuid
+
+from tests.test_dataset import make_dataset_items
+from tests.helpers import (
+    TEST_BOX_ANNOTATIONS,
+    TEST_BOX_PREDICTIONS,
+    TEST_SLICE_NAME,
+    TEST_EVAL_FUNCTION_ID,
+    EVAL_FUNCTION_THRESHOLD,
+    get_uuid,
+)
+
+from nucleus import BoxAnnotation, BoxPrediction
+from nucleus.job import AsyncJob
+from nucleus.modelci.unit_test import ThresholdComparison
+from nucleus.modelci.unit_test_evaluation import (
+    UnitTestEvaluation,
+    UnitTestItemEvaluation,
+)
+
+
+@pytest.mark.integration
+def test_unit_test_evaluation(CLIENT, dataset, model, unit_test):
+    annotation = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
+    dataset.annotate(annotations=[annotation])
+    prediction = BoxPrediction(**TEST_BOX_PREDICTIONS[0])
+    dataset.upload_predictions(model, [prediction])
+
+    unit_test.add_metric(
+        eval_function_id=TEST_EVAL_FUNCTION_ID,
+        threshold=EVAL_FUNCTION_THRESHOLD,
+        threshold_comparison=ThresholdComparison.GREATER_THAN,
+    )
+
+    job: AsyncJob = CLIENT.modelci.evaluate_model_on_unit_tests(
+        model.id, [unit_test.name]
+    )
+    job.sleep_until_complete()
+
+    evaluations = unit_test.get_eval_history()
+    assert isinstance(evaluations, list)
+    assert len(evaluations) == 1
+    assert isinstance(evaluations[0], UnitTestEvaluation)
+    assert evaluations[0].unit_test_id == unit_test.id
+    assert evaluations[0].model_id == model.id
+
+    item_evaluations = evaluations[0].item_evals
+    assert isinstance(item_evaluations, list)
+    assert len(item_evaluations) == 1  # 1 item in slice
+    assert isinstance(item_evaluations[0], UnitTestItemEvaluation)
+    assert all(
+        eval.evaluation_id == evaluations[0].id for eval in item_evaluations
+    )
+    assert all(eval.unit_test_id == unit_test.id for eval in item_evaluations)


### PR DESCRIPTION
The preceding PR to this one (https://github.com/scaleapi/nucleus-python-client/pull/149) was failing this unit test because the test evaluation endpoint in scaleapi was not behaving as expected. As a result, this PR was created to add in the unit test after the test evaluation endpoint was fixed.

Also, update the interface of unit test evaluation to allow for `model.evaluate(unit_test_names)`

[sc285224](https://app.shortcut.com/scaleai/story/285224)
[sc251115](https://app.shortcut.com/scaleai/story/251115)