### PR TITLE
Fix merge error -> recursion bug in dataset.info

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -241,7 +241,9 @@ class Dataset:
         Returns:
             :class:`DatasetInfo`
         """
-        response = self._client.dataset_info(self.id)
+        response = self._client.make_request(
+            {}, f"dataset/{self.id}/info", requests.get
+        )
         dataset_info = DatasetInfo.parse_obj(response)
         return dataset_info
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.3.0"
+version = "0.3.1"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
A merge error slipped into last PR. `dataset.info` was not moved properly. 

This PR fixes that the request is handled in the `Dataset` class.