### PR TITLE
Support for default category taxonomy

### DIFF
--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -515,16 +515,16 @@ class CategoryAnnotation(Annotation):
 
         category = CategoryAnnotation(
             label="dress",
-            taxonomy_name="clothing_type",
             reference_id="image_1",
+            taxonomy_name="clothing_type",
             metadata={"dress_color": "navy"}
         )
 
     Parameters:
         label (str): The label for this annotation.
-        taxonomy_name (str): The name of the taxonomy this annotation conforms to.
-          See :meth:`Dataset.add_taxonomy`.
         reference_id (str): User-defined ID of the image to which to apply this annotation.
+        taxonomy_name (Optional[str]): The name of the taxonomy this annotation conforms to.
+          See :meth:`Dataset.add_taxonomy`.
         metadata (Optional[Dict]): Arbitrary key/value dictionary of info to attach to this annotation.
           Strings, floats and ints are supported best by querying and insights
           features within Nucleus. For more details see our `metadata guide
@@ -543,8 +543,8 @@ class CategoryAnnotation(Annotation):
     def from_json(cls, payload: dict):
         return cls(
             label=payload[LABEL_KEY],
-            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )
 
@@ -577,8 +577,8 @@ class MultiCategoryAnnotation(Annotation):
     def from_json(cls, payload: dict):
         return cls(
             labels=payload[LABELS_KEY],
-            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )
 

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -532,8 +532,8 @@ class CategoryAnnotation(Annotation):
     """
 
     label: str
-    taxonomy_name: str
     reference_id: str
+    taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = None
 
     def __post_init__(self):
@@ -543,20 +543,22 @@ class CategoryAnnotation(Annotation):
     def from_json(cls, payload: dict):
         return cls(
             label=payload[LABEL_KEY],
-            taxonomy_name=payload[TAXONOMY_NAME_KEY],
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
             metadata=payload.get(METADATA_KEY, {}),
         )
 
     def to_payload(self) -> dict:
-        return {
+        payload = {
             LABEL_KEY: self.label,
-            TAXONOMY_NAME_KEY: self.taxonomy_name,
             TYPE_KEY: CATEGORY_TYPE,
             GEOMETRY_KEY: {},
             REFERENCE_ID_KEY: self.reference_id,
             METADATA_KEY: self.metadata,
         }
+        if self.taxonomy_name is not None:
+            payload[TAXONOMY_NAME_KEY] = self.taxonomy_name
+        return payload
 
 
 @dataclass
@@ -564,8 +566,8 @@ class MultiCategoryAnnotation(Annotation):
     """This class is not yet supported: MultiCategory annotation support coming soon!"""
 
     labels: List[str]
-    taxonomy_name: str
     reference_id: str
+    taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = None
 
     def __post_init__(self):
@@ -575,20 +577,22 @@ class MultiCategoryAnnotation(Annotation):
     def from_json(cls, payload: dict):
         return cls(
             labels=payload[LABELS_KEY],
-            taxonomy_name=payload[TAXONOMY_NAME_KEY],
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
             metadata=payload.get(METADATA_KEY, {}),
         )
 
     def to_payload(self) -> dict:
-        return {
+        payload = {
             LABELS_KEY: self.labels,
-            TAXONOMY_NAME_KEY: self.taxonomy_name,
             TYPE_KEY: MULTICATEGORY_TYPE,
             GEOMETRY_KEY: {},
             REFERENCE_ID_KEY: self.reference_id,
             METADATA_KEY: self.metadata,
         }
+        if self.taxonomy_name is not None:
+            payload[TAXONOMY_NAME_KEY] = self.taxonomy_name
+        return payload
 
 
 def is_local_path(path: str) -> bool:

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -348,9 +348,9 @@ class CategoryPrediction(CategoryAnnotation):
 
     Parameters:
         label: The label for this annotation (e.g. car, pedestrian, bicycle).
+        reference_id: The reference ID of the image you wish to apply this annotation to.
         taxonomy_name: The name of the taxonomy this annotation conforms to.
           See :meth:`Dataset.add_taxonomy`.
-        reference_id: The reference ID of the image you wish to apply this annotation to.
         confidence: 0-1 indicating the confidence of the prediction.
         class_pdf: An optional complete class probability distribution on this
             prediction. Each value should be between 0 and 1 (inclusive), and sum up to
@@ -365,8 +365,8 @@ class CategoryPrediction(CategoryAnnotation):
     def __init__(
         self,
         label: str,
-        taxonomy_name: str,
         reference_id: str,
+        taxonomy_name: Optional[str] = None,
         confidence: Optional[float] = None,
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.3.1"
+version = "0.3.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -172,7 +172,6 @@ TEST_DEFAULT_CATEGORY_ANNOTATIONS = [
     {
         "label": f"[Pytest] Category Label ${i}",
         "reference_id": reference_id_from_url(TEST_IMG_URLS[i]),
-        "taxonomy_name": "[Pytest] Category Taxonomy 1",
     }
     for i in range(len(TEST_IMG_URLS))
 ]
@@ -189,7 +188,6 @@ TEST_MULTICATEGORY_ANNOTATIONS = [
     for i in range(len(TEST_IMG_URLS))
 ]
 
-
 TEST_DEFAULT_MULTICATEGORY_ANNOTATIONS = [
     {
         "labels": [
@@ -197,7 +195,6 @@ TEST_DEFAULT_MULTICATEGORY_ANNOTATIONS = [
             f"[Pytest] MultiCategory Label ${i+1}",
         ],
         "reference_id": reference_id_from_url(TEST_IMG_URLS[i]),
-        "taxonomy_name": "[Pytest] MultiCategory Taxonomy 1",
     }
     for i in range(len(TEST_IMG_URLS))
 ]
@@ -346,18 +343,20 @@ def assert_category_annotation_matches_dict(
     annotation_instance, annotation_dict
 ):
     assert annotation_instance.label == annotation_dict["label"]
-    assert (
-        annotation_instance.taxonomy_name == annotation_dict["taxonomy_name"]
-    )
+    if annotation_instance.taxonomy_name:
+        assert annotation_instance.taxonomy_name == annotation_dict.get(
+            "taxonomy_name", None
+        )
 
 
 def assert_multicategory_annotation_matches_dict(
     annotation_instance, annotation_dict
 ):
     assert set(annotation_instance.labels) == set(annotation_dict["labels"])
-    assert (
-        annotation_instance.taxonomy_name == annotation_dict["taxonomy_name"]
-    )
+    if annotation_instance.taxonomy_name:
+        assert annotation_instance.taxonomy_name == annotation_dict.get(
+            "taxonomy_name", None
+        )
 
 
 def assert_segmentation_annotation_matches_dict(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -168,7 +168,29 @@ TEST_CATEGORY_ANNOTATIONS = [
     for i in range(len(TEST_IMG_URLS))
 ]
 
+TEST_DEFAULT_CATEGORY_ANNOTATIONS = [
+    {
+        "label": f"[Pytest] Category Label ${i}",
+        "reference_id": reference_id_from_url(TEST_IMG_URLS[i]),
+        "taxonomy_name": "[Pytest] Category Taxonomy 1",
+    }
+    for i in range(len(TEST_IMG_URLS))
+]
+
 TEST_MULTICATEGORY_ANNOTATIONS = [
+    {
+        "labels": [
+            f"[Pytest] MultiCategory Label ${i}",
+            f"[Pytest] MultiCategory Label ${i+1}",
+        ],
+        "reference_id": reference_id_from_url(TEST_IMG_URLS[i]),
+        "taxonomy_name": "[Pytest] MultiCategory Taxonomy 1",
+    }
+    for i in range(len(TEST_IMG_URLS))
+]
+
+
+TEST_DEFAULT_MULTICATEGORY_ANNOTATIONS = [
     {
         "labels": [
             f"[Pytest] MultiCategory Label ${i}",
@@ -251,6 +273,20 @@ TEST_CATEGORY_PREDICTIONS = [
         "confidence": 0.10 * i,
     }
     for i in range(len(TEST_CATEGORY_ANNOTATIONS))
+]
+
+TEST_DEFAULT_CATEGORY_PREDICTIONS = [
+    {
+        **TEST_DEFAULT_CATEGORY_ANNOTATIONS[i],
+        "confidence": 0.10 * i,
+        "class_pdf": TEST_CATEGORY_MODEL_PDF,
+    }
+    if i != 0
+    else {
+        **TEST_DEFAULT_CATEGORY_ANNOTATIONS[i],
+        "confidence": 0.10 * i,
+    }
+    for i in range(len(TEST_DEFAULT_CATEGORY_ANNOTATIONS))
 ]
 
 TEST_INDEX_EMBEDDINGS_FILE = "https://raw.githubusercontent.com/scaleapi/nucleus-python-client/master/tests/testdata/pytest_embeddings_payload.json"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -156,6 +156,7 @@ def test_default_category_gt_upload(dataset):
     ]
     assert len(response) == 1
     response_annotation = response[0]
+
     assert_category_annotation_matches_dict(
         response_annotation, TEST_DEFAULT_CATEGORY_ANNOTATIONS[0]
     )
@@ -715,13 +716,13 @@ def test_multicategory_gt_deletion(dataset):
 
 
 @pytest.mark.integration
-def test_default_category_pred_upload_async(dataset):
-    prediction_default_category = CategoryAnnotation.from_json(
+def test_default_category_gt_upload_async(dataset):
+    annotation = CategoryAnnotation.from_json(
         TEST_DEFAULT_CATEGORY_ANNOTATIONS[0]
     )
     job: AsyncJob = dataset.annotate(
         annotations=[
-            prediction_default_category,
+            annotation,
         ],
         asynchronous=True,
     )

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -311,9 +311,6 @@ def test_category_pred_upload_update(model_run):
 
     # Copy so we don't modify the original.
     prediction_update_params = dict(TEST_CATEGORY_PREDICTIONS[1])
-    prediction_update_params["annotation_id"] = TEST_CATEGORY_PREDICTIONS[0][
-        "taxonomy_name"
-    ]
     prediction_update_params["reference_id"] = TEST_CATEGORY_PREDICTIONS[0][
         "reference_id"
     ]
@@ -339,9 +336,6 @@ def test_category_pred_upload_ignore(model_run):
 
     # Copy so we don't modify the original.
     prediction_update_params = dict(TEST_CATEGORY_PREDICTIONS[1])
-    prediction_update_params["annotation_id"] = TEST_CATEGORY_PREDICTIONS[0][
-        "taxonomy_name"
-    ]
     prediction_update_params["reference_id"] = TEST_CATEGORY_PREDICTIONS[0][
         "reference_id"
     ]
@@ -371,9 +365,6 @@ def test_default_category_pred_upload_update(model_run):
     # Copy so we don't modify the original.
     prediction_update_params = dict(TEST_DEFAULT_CATEGORY_PREDICTIONS[1])
     prediction_update_params[
-        "annotation_id"
-    ] = TEST_DEFAULT_CATEGORY_PREDICTIONS[0]["taxonomy_name"]
-    prediction_update_params[
         "reference_id"
     ] = TEST_DEFAULT_CATEGORY_PREDICTIONS[0]["reference_id"]
 
@@ -400,9 +391,6 @@ def test_default_category_pred_upload_ignore(model_run):
 
     # Copy so we don't modify the original.
     prediction_update_params = dict(TEST_DEFAULT_CATEGORY_PREDICTIONS[1])
-    prediction_update_params[
-        "annotation_id"
-    ] = TEST_DEFAULT_CATEGORY_PREDICTIONS[0]["taxonomy_name"]
     prediction_update_params[
         "reference_id"
     ] = TEST_DEFAULT_CATEGORY_PREDICTIONS[0]["reference_id"]


### PR DESCRIPTION
Adds API support for a default category taxonomy so that users don't have to explicitly specify a taxonomy ahead of time. Unit test included in PR and tested with code in scaleapi/scaleapi#33281.

[[sc-268730]](https://app.shortcut.com/scaleai/story/268730)