### PR TITLE
[Model CI] Add API for retrieving dataset items associated with unit test

### DIFF
--- a/nucleus/modelci/unit_test.py
+++ b/nucleus/modelci/unit_test.py
@@ -12,6 +12,7 @@ import requests
 
 from nucleus.connection import Connection
 from nucleus.constants import NAME_KEY, SLICE_ID_KEY
+from nucleus.dataset_item import DatasetItem
 
 from .constants import (
     EVAL_FUNCTION_ID_KEY,
@@ -24,6 +25,7 @@ from .constants import (
 from .unit_test_evaluation import UnitTestEvaluation
 
 EVALUATIONS_KEY = "evaluations"
+DATASET_ITEMS_KEY = "dataset_items"
 
 
 class ThresholdComparison(Enum):
@@ -171,4 +173,14 @@ class UnitTest:
         return [
             UnitTestEvaluation(eval[ID_KEY], self.connection)
             for eval in response[EVALUATIONS_KEY]
+        ]
+
+    def get_items(self) -> List[DatasetItem]:
+        response = self.connection.make_request(
+            {},
+            f"modelci/unit_test/{self.id}/items",
+            requests_command=requests.get,
+        )
+        return [
+            DatasetItem.from_json(item) for item in response[DATASET_ITEMS_KEY]
         ]

--- a/tests/modelci/test_unit_test.py
+++ b/tests/modelci/test_unit_test.py
@@ -56,7 +56,7 @@ def test_unit_test_items(CLIENT, dataset):
     test_name = "unit_test_" + get_uuid()  # use uuid to make unique
     slc = dataset.create_slice(
         name=TEST_SLICE_NAME,
-        reference_ids=[items[0].reference_id],
+        reference_ids=[item.reference_id for item in items],
     )
 
     unit_test = CLIENT.modelci.create_unit_test(
@@ -64,5 +64,9 @@ def test_unit_test_items(CLIENT, dataset):
         slice_id=slc.slice_id,
     )
 
-    assert items == unit_test.get_items()
+    expected_items_locations = [item.image_location for item in items]
+    actual_items_locations = [
+        item.image_location for item in unit_test.get_items()
+    ]
+    assert expected_items_locations == actual_items_locations
     CLIENT.modelci.delete_unit_test(unit_test.id)

--- a/tests/modelci/test_unit_test.py
+++ b/tests/modelci/test_unit_test.py
@@ -45,3 +45,24 @@ def test_list_unit_test(CLIENT, dataset):
     unit_tests = CLIENT.modelci.list_unit_tests()
     assert all(isinstance(unit_test, UnitTest) for unit_test in unit_tests)
     assert unit_test in unit_tests
+
+    CLIENT.modelci.delete_unit_test(unit_test.id)
+
+
+def test_unit_test_items(CLIENT, dataset):
+    # create some dataset_items for the unit test to reference
+    items = make_dataset_items()
+    dataset.append(items)
+    test_name = "unit_test_" + get_uuid()  # use uuid to make unique
+    slc = dataset.create_slice(
+        name=TEST_SLICE_NAME,
+        reference_ids=[items[0].reference_id],
+    )
+
+    unit_test = CLIENT.modelci.create_unit_test(
+        name=test_name,
+        slice_id=slc.slice_id,
+    )
+
+    assert items == unit_test.get_items()
+    CLIENT.modelci.delete_unit_test(unit_test.id)

--- a/tests/modelci/test_unit_test_evaluation.py
+++ b/tests/modelci/test_unit_test_evaluation.py
@@ -14,10 +14,7 @@ from tests.helpers import (
     TEST_BOX_ANNOTATIONS,
     TEST_BOX_PREDICTIONS,
     TEST_EVAL_FUNCTION_ID,
-    TEST_SLICE_NAME,
-    get_uuid,
 )
-from tests.test_dataset import make_dataset_items
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Pull Request Summary
Return full information for Model CI dataset items query

# Test Plan
Added unit test.

# Shortcut Ticket
[[sc-278939]](https://app.shortcut.com/scaleai/story/278939)