### PR TITLE
[Model CI] Update format of job errors

### DIFF
--- a/nucleus/job.py
+++ b/nucleus/job.py
@@ -11,6 +11,7 @@ from nucleus.constants import (
     JOB_TYPE_KEY,
     STATUS_KEY,
 )
+from nucleus.utils import replace_double_slashes
 
 JOB_POLLING_INTERVAL = 5
 
@@ -82,11 +83,12 @@ class AsyncJob:
                     '{"annotation":{"label":"car","type":"box","geometry":{"x":50,"y":60,"width":70,"height":80},"referenceId":"bad_ref_id","annotationId":"attempted_annot_upload","metadata":{}},"error":"Item with id bad_ref_id doesn\'t exist."}'
                 ]
         """
-        return self.client.make_request(
+        errors = self.client.make_request(
             payload={},
             route=f"job/{self.job_id}/errors",
             requests_command=requests.get,
         )
+        return [replace_double_slashes(error) for error in errors]
 
     def sleep_until_complete(self, verbose_std_out=True):
         """Blocks until the job completes or errors.
@@ -132,4 +134,5 @@ class JobError(Exception):
             f"The final status message was: {final_status_message} \n"
             f"For more detailed error messages you can call {str(job)}.errors()"
         )
+        message = replace_double_slashes(message)
         super().__init__(message)

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -41,6 +41,12 @@ from .prediction import (
 )
 from .scene import LidarScene
 
+STRING_REPLACEMENTS = {
+    "\\\\n": "\n",
+    "\\\\t": "\t",
+    '\\\\"': '"',
+}
+
 
 def format_prediction_response(
     response: dict,
@@ -227,3 +233,9 @@ def serialize_and_write_to_presigned_url(
     strio.seek(0)
     upload_to_presigned_url(response["signed_url"], strio)
     return request_id
+
+
+def replace_double_slashes(s):
+    for key, val in STRING_REPLACEMENTS.items():
+        s = s.replace(key, val)
+    return s

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -235,7 +235,7 @@ def serialize_and_write_to_presigned_url(
     return request_id
 
 
-def replace_double_slashes(s):
+def replace_double_slashes(s: str) -> str:
     for key, val in STRING_REPLACEMENTS.items():
         s = s.replace(key, val)
     return s


### PR DESCRIPTION
Update job errors to replace double backslashes with the respective escaped characters to make printing look nice.

Before
```
JobError: The job reported a final status of Errored This could, however, mean a partial success with some successes and some failures. The final status message was: {'final_error': 'Encountered error during unit test evaluation: "Traceback (most recent call last):\\n  File \\"/usr/local/lib/python3.8/site-packages/celery/app/trace.py\\", line 405, in trace_task\\n    R = retval = fun(*args, **kwargs)\\n  File \\"/usr/local/lib/python3.8/site-packages/celery/app/trace.py\\", line 697, in __protected_call__\\n    return self.run(*args, **kwargs)\\n  File \\"/workspace/model_ci/tasks.py\\", line 71, in evaluate\\n    eval_func = cloudpickle.loads(base64.b64decode(function))\\nModuleNotFoundError: No module named \'example_evaluation_functions\'\\n"'} 
For more detailed error messages you can call AsyncJob(job_id='job_c6qcvk6kr9k3028x0860', job_last_known_status='Errored', job_type='testEvaluation', job_creation_time='2021-12-07T02:58:20.426Z', client=Connection(api_key='', endpoint='http://localhost:3000/v1/nucleus')).errors()
```

After
```
JobError: The job reported a final status of Errored This could, however, mean a partial success with some successes and some failures. The final status message was: {'final_error': 'Encountered error during unit test evaluation: "Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 405, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 697, in __protected_call__
    return self.run(*args, **kwargs)
  File "/workspace/model_ci/tasks.py", line 71, in evaluate
    eval_func = cloudpickle.loads(base64.b64decode(function))
ModuleNotFoundError: No module named \'example_evaluation_functions\'
"'} 
For more detailed error messages you can call AsyncJob(job_id='job_c6qctptkr9k3028x07x0', job_last_known_status='Errored', job_type='testEvaluation', job_creation_time='2021-12-07T02:56:27.075Z', client=Connection(api_key='', endpoint='http://localhost:3000/v1/nucleus')).errors()
```