### PR TITLE
move Model CI docs to its own page

### DIFF
--- a/docs/_templates/python/module.rst
+++ b/docs/_templates/python/module.rst
@@ -2,7 +2,7 @@
 :orphan:
 
 {% endif %}
-API Reference
+{{ obj.name }}
 =============
 
 .. py:module:: {{ obj.name }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Sections
    :maxdepth: 4
 
    api/nucleus/index
+   api/nucleus/modelci/index
 
 
 Index

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "LidarScene",
     "LidarScene",
     "Model",
-    "ModelCI",
     "ModelCreationError",
     # "MultiCategoryAnnotation", # coming soon!
     "NotFoundError",
@@ -33,7 +32,6 @@ __all__ = [
     "SegmentationAnnotation",
     "SegmentationPrediction",
     "Slice",
-    "UnitTest",
 ]
 
 import os
@@ -108,7 +106,7 @@ from .job import AsyncJob
 from .logger import logger
 from .model import Model
 from .model_run import ModelRun
-from .modelci import AvailableEvalFunctions, ModelCI, UnitTest, UnitTestMetric
+from .modelci import ModelCI
 from .payload_constructor import (
     construct_annotation_payload,
     construct_append_payload,

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -1,17 +1,8 @@
 """Model CI Python Library."""
 
 __all__ = [
-    "AvailableEvalFunctions",
-    "Connection",
-    "EvalFunctionEntry",
-    "EvaluationCriterion",
-    "GetEvalFunctions",
     "ModelCI",
-    "ThresholdComparison",
     "UnitTest",
-    "UnitTestEvaluation",
-    "UnitTestItemEvaluation",
-    "UnitTestMetric",
 ]
 
 from typing import List

--- a/nucleus/modelci/__init__.py
+++ b/nucleus/modelci/__init__.py
@@ -1,4 +1,19 @@
 """Model CI Python Library."""
+
+__all__ = [
+    "AvailableEvalFunctions",
+    "Connection",
+    "EvalFunctionEntry",
+    "EvaluationCriterion",
+    "GetEvalFunctions",
+    "ModelCI",
+    "ThresholdComparison",
+    "UnitTest",
+    "UnitTestEvaluation",
+    "UnitTestItemEvaluation",
+    "UnitTestMetric",
+]
+
 from typing import List
 
 from nucleus.connection import Connection

--- a/nucleus/modelci/data_transfer_objects/eval_function.py
+++ b/nucleus/modelci/data_transfer_objects/eval_function.py
@@ -8,9 +8,11 @@ from ..constants import ThresholdComparison
 
 class EvaluationCriterion(ImmutableModel):
     """
-    eval_function_id: ID of evaluation function
-    threshold_comparison: comparator for evaluation. i.e. threshold=0.5 and threshold_comparator > implies that a test only passes if score > 0.5.
-    threshold: numerical threshold that together with threshold comparison, defines success criteria for test evaluation.
+
+    Parameters:
+        eval_function_id: ID of evaluation function
+        threshold_comparison (:class:`ThresholdComparison`): comparator for evaluation. i.e. threshold=0.5 and threshold_comparator > implies that a test only passes if score > 0.5.
+        threshold: numerical threshold that together with threshold comparison, defines success criteria for test evaluation.
     """
 
     # TODO: Having only eval_function_id hurts readability -> Add function name


### PR DESCRIPTION
Autodeployed docs: https://scale-ai-nucleus-python-sdk--176.com.readthedocs.build/en/176/
* moved Model CI docs to its own page
* cleaned up some imports
    * let me know if this was breaking
    * or if you want to change the members surfaced under `nucleus.modelci`