### PR TITLE
Fix Scene metadata update workflow: get scene followed by re-upload should be seamless

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1016,7 +1016,7 @@ class Dataset:
             :class:`Scene<LidarScene>`: A scene object containing frames, which
             in turn contain pointcloud or image items.
         """
-        return Scene.from_json(
+        return LidarScene.from_json(
             self._client.make_request(
                 payload=None,
                 route=f"dataset/{self.id}/scene/{reference_id}",

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -184,6 +184,10 @@ def serialize_and_write(
     upload_units: Sequence[Union[DatasetItem, Annotation, LidarScene]],
     file_pointer,
 ):
+    if len(upload_units) == 0:
+        raise ValueError(
+            "Expecting at least one object when serializing objects to upload, but got zero.  Please try again."
+        )
     for unit in upload_units:
         try:
             if isinstance(unit, (DatasetItem, Annotation, LidarScene)):


### PR DESCRIPTION
Corresponds to: https://github.com/scaleapi/scaleapi/pull/33731

The workflow of scene.get -> scene.upload was broken because the object returned by get was instantiated as Scene instead of lidar scene..  Added pytest integration test to handle this case as well as the update flag causing update on conflict behavior, which was previously missing.