### PR TITLE
refactor Slice methods to avoid fetching all items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.2) - 2021-12-16
+
+### Added
+- `Slice.name` property that fetches the Slice's user-defined name.
+  - The Slice's items are no longer fetched unnecessarily; this used to cause considerable latency.
+- `Slice.items` property that fetches all items contained in the Slice.
+
+### Changed
+- `Slice.info()` now only retrieves the Slice's `name`, `slice_id`, and `dataset_id`.
+  - The Slice's items are no longer fetched unnecessarily; this used to cause considerable latency.
+  - This method issues a warning to use `Slice.items` when attempting to `items`.
+
+[###](###) Deprecated
+- `NucleusClient.slice_info(..)` is deprecated in favor of `Slice.info()`.
+
+## [0.4.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.1) - 2021-12-13
+
+### Changed
+- Datasets in Nucleus now fall under two categories: scene or item.
+  - Scene Datasets can only have scenes uploaded to them.
+  - Item Datasets can only have items uploaded to them.
+- `NucleusClient.create_dataset` now requires a boolean parameter `is_scene` to immutably set whether the Dataset is a scene or item Dataset.
+
 ## [0.4.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.0) - 2021-08-12
 
 ### Added

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -738,8 +738,9 @@ class NucleusClient:
         """
         return Slice(slice_id, self)
 
+    @deprecated("Prefer calling Slice.info instead.")
     def slice_info(self, slice_id: str) -> dict:
-        # TODO: migrate to Slice method and deprecate
+        # TODO: deprecate in favor of Slice.info
         response = self.make_request(
             {},
             f"slice/{slice_id}",

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -181,7 +181,7 @@ class Slice:
         for item_metadata in self.items:
             yield format_dataset_item_response(
                 self._client.dataitem_loc(
-                    dataset_id=info["dataset_id"],
+                    dataset_id=self.dataset_id,
                     dataset_item_id=item_metadata["id"],
                 )
             )
@@ -303,7 +303,9 @@ def check_annotations_are_in_slice(
         annotation.reference_id
         for annotation in annotations
         if annotation.reference_id is not None
-    }.difference({item_metadata["ref_id"] for item_metadata in self.items})
+    }.difference(
+        {item_metadata["ref_id"] for item_metadata in slice_to_check.items}
+    )
     if reference_ids_not_found_in_slice:
         annotations_are_in_slice = False
     else:

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -7,7 +7,7 @@ from nucleus.annotation import Annotation
 from nucleus.constants import EXPORTED_ROWS
 from nucleus.dataset_item import DatasetItem
 from nucleus.job import AsyncJob
-from nucleus.utils import convert_export_payload, format_dataset_item_response
+from nucleus.utils import convert_export_payload, format_dataset_item_response, KeyErrorDict
 
 
 class Slice:
@@ -41,6 +41,7 @@ class Slice:
         self.id = slice_id
         self._slice_id = slice_id
         self._client = client
+        self._name = None
         self._dataset_id = None
 
     def __repr__(self):
@@ -52,23 +53,8 @@ class Slice:
                 return True
         return False
 
-    @property
-    def slice_id(self):
-        warnings.warn(
-            "Using Slice.slice_id is deprecated. Prefer using Slice.id",
-            DeprecationWarning,
-        )
-        return self._slice_id
-
-    @property
-    def dataset_id(self):
-        """The ID of the Dataset to which the Slice belongs."""
-        if self._dataset_id is None:
-            self.info()
-        return self._dataset_id
-
-    def info(self) -> dict:
-        """Retrieves info and items of the Slice.
+    def _fetch_all(self) -> dict:
+        """Retrieves info and all items of the Slice.
 
         Returns:
             A dict mapping keys to the corresponding info retrieved.
@@ -86,14 +72,40 @@ class Slice:
                     }]
                 }
         """
-        info = self._client.make_request(
+        response = self._client.make_request(
             {}, f"slice/{self.id}", requests_command=requests.get
         )
-        self._dataset_id = info["dataset_id"]
-        return info
+        return response
 
-    def summary(self) -> dict:
-        """Retrieves the name and dataset_id of the Slice.
+    @property
+    def slice_id(self):
+        warnings.warn(
+            "Using Slice.slice_id is deprecated. Prefer using Slice.id",
+            DeprecationWarning,
+        )
+        return self._slice_id
+
+    @property
+    def name(self):
+        """The name of the Slice."""
+        if self._name is None:
+            self._name = self.info()["name"]
+        return self._name
+
+    @property
+    def dataset_id(self):
+        """The ID of the Dataset to which the Slice belongs."""
+        if self._dataset_id is None:
+            self._dataset_id = self.info()["dataset_id"]
+        return self._dataset_id
+
+    @property
+    def items(self):
+        """All DatasetItems contained in the Slice."""
+        return self._fetch_all()["dataset_items"]
+
+    def info(self) -> dict:
+        """Retrieves the name, slice_id, and dataset_id of the Slice.
 
         Returns:
             A dict mapping keys to the corresponding info retrieved.
@@ -102,13 +114,16 @@ class Slice:
                 {
                     "name": Union[str, int],
                     "slice_id": str,
-                    "dataset_id": str
+                    "dataset_id": str,
                 }
         """
-        info = self._client.make_request(
+        info = KeyErrorDict(
+            items="The 'items' key is now deprecated for Slice.info. Use Slice.items instead."
+        )
+        res = self._client.make_request(
             {}, f"slice/{self.id}/info", requests_command=requests.get
         )
-        self._dataset_id = info["dataset_id"]
+        info.update(res)
         return info
 
     def append(
@@ -159,8 +174,7 @@ class Slice:
                     }
                 }]
         """
-        info = self.info()
-        for item_metadata in info["dataset_items"]:
+        for item_metadata in self.items:
             yield format_dataset_item_response(
                 self._client.dataitem_loc(
                     dataset_id=info["dataset_id"],
@@ -281,14 +295,12 @@ def check_annotations_are_in_slice(
         1. True if all Annotations are in the Slice, False otherwise;
         2. List of reference IDs not in the Slice.
     """
-    info = slice_to_check.info()
-
     reference_ids_not_found_in_slice = {
         annotation.reference_id
         for annotation in annotations
         if annotation.reference_id is not None
     }.difference(
-        {item_metadata["ref_id"] for item_metadata in info["dataset_items"]}
+        {item_metadata["ref_id"] for item_metadata in self.items}
     )
     if reference_ids_not_found_in_slice:
         annotations_are_in_slice = False

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -76,6 +76,7 @@ class Slice:
 
                 {
                     "name": Union[str, int],
+                    "slice_id": str,
                     "dataset_id": str,
                     "dataset_items": List[{
                         "id": str,
@@ -85,7 +86,28 @@ class Slice:
                     }]
                 }
         """
-        info = self._client.slice_info(self.id)
+        info = self._client.make_request(
+            {}, f"slice/{self.id}", requests_command=requests.get
+        )
+        self._dataset_id = info["dataset_id"]
+        return info
+
+    def summary(self) -> dict:
+        """Retrieves the name and dataset_id of the Slice.
+
+        Returns:
+            A dict mapping keys to the corresponding info retrieved.
+            ::
+
+                {
+                    "name": Union[str, int],
+                    "slice_id": str,
+                    "dataset_id": str
+                }
+        """
+        info = self._client.make_request(
+            {}, f"slice/{self.id}/info", requests_command=requests.get
+        )
         self._dataset_id = info["dataset_id"]
         return info
 

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -7,7 +7,11 @@ from nucleus.annotation import Annotation
 from nucleus.constants import EXPORTED_ROWS
 from nucleus.dataset_item import DatasetItem
 from nucleus.job import AsyncJob
-from nucleus.utils import convert_export_payload, format_dataset_item_response, KeyErrorDict
+from nucleus.utils import (
+    convert_export_payload,
+    format_dataset_item_response,
+    KeyErrorDict,
+)
 
 
 class Slice:
@@ -299,9 +303,7 @@ def check_annotations_are_in_slice(
         annotation.reference_id
         for annotation in annotations
         if annotation.reference_id is not None
-    }.difference(
-        {item_metadata["ref_id"] for item_metadata in self.items}
-    )
+    }.difference({item_metadata["ref_id"] for item_metadata in self.items})
     if reference_ids_not_found_in_slice:
         annotations_are_in_slice = False
     else:

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -8,9 +8,9 @@ from nucleus.constants import EXPORTED_ROWS
 from nucleus.dataset_item import DatasetItem
 from nucleus.job import AsyncJob
 from nucleus.utils import (
+    KeyErrorDict,
     convert_export_payload,
     format_dataset_item_response,
-    KeyErrorDict,
 )
 
 

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -56,7 +56,7 @@ class KeyErrorDict(dict):
     """
 
     def __init__(self, **kwargs: dict) -> None:
-        self._deprecated = dict()
+        self._deprecated = {}
 
         for key, msg in kwargs.items():
             if not isinstance(key, str):
@@ -70,14 +70,16 @@ class KeyErrorDict(dict):
 
             self._deprecated[key] = msg
 
+        super().__init__()
+
     def __missing__(self, key):
-        """Raises KeyError for deprecated keys, otherwise returns the value."""
+        """Raises KeyError for deprecated keys, otherwise uses base dict logic."""
         if key in self._deprecated:
             raise KeyError(self._deprecated[key])
         try:
             super().__missing__(key)
-        except AttributeError:
-            raise KeyError(key)
+        except AttributeError as e:
+            raise KeyError(key) from e
 
 
 def format_prediction_response(

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -48,6 +48,32 @@ STRING_REPLACEMENTS = {
 }
 
 
+class KeyErrorDict(dict):
+    """Wrapper for response dicts with deprecated keys.
+
+    Parameters:
+        **kwargs: Mapping from the deprecated key to a warning message.
+    """
+    def __init__(self, **kwargs: dict) -> None:
+        self._deprecated = dict()
+
+        for key, msg in kwargs.items():
+            if not isinstance(key, str):
+                raise TypeError(f"All keys must be strings! Received non-string '{key}'")
+            if not isinstance(msg, str):
+                raise TypeError(f"All warning messages must be strings! Received non-string '{msg}'")
+
+            self._deprecated[key] = msg
+
+    def __missing__(self, key):
+        """Raises KeyError for deprecated keys, otherwise returns the value."""
+        if key in self._deprecated:
+            raise KeyError(self._deprecated[key])
+        try:
+            super().__missing__(key)
+        except AttributeError:
+            raise KeyError(key)
+
 def format_prediction_response(
     response: dict,
 ) -> Union[

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -54,14 +54,19 @@ class KeyErrorDict(dict):
     Parameters:
         **kwargs: Mapping from the deprecated key to a warning message.
     """
+
     def __init__(self, **kwargs: dict) -> None:
         self._deprecated = dict()
 
         for key, msg in kwargs.items():
             if not isinstance(key, str):
-                raise TypeError(f"All keys must be strings! Received non-string '{key}'")
+                raise TypeError(
+                    f"All keys must be strings! Received non-string '{key}'"
+                )
             if not isinstance(msg, str):
-                raise TypeError(f"All warning messages must be strings! Received non-string '{msg}'")
+                raise TypeError(
+                    f"All warning messages must be strings! Received non-string '{msg}'"
+                )
 
             self._deprecated[key] = msg
 
@@ -73,6 +78,7 @@ class KeyErrorDict(dict):
             super().__missing__(key)
         except AttributeError:
             raise KeyError(key)
+
 
 def format_prediction_response(
     response: dict,

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -55,7 +55,7 @@ class KeyErrorDict(dict):
         **kwargs: Mapping from the deprecated key to a warning message.
     """
 
-    def __init__(self, **kwargs: dict) -> None:
+    def __init__(self, **kwargs):
         self._deprecated = {}
 
         for key, msg in kwargs.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.4.1"
+version = "0.4.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -74,6 +74,10 @@ def test_slice_create_and_delete_and_list(dataset):
             or item.reference_id == response["dataset_items"][1]["ref_id"]
         )
 
+    response = slc.summary()
+    assert response["name"] == TEST_SLICE_NAME
+    assert response["dataset_id"] == dataset.id
+
 
 def test_slice_create_and_export(dataset):
     # Dataset upload

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -64,18 +64,20 @@ def test_slice_create_and_delete_and_list(dataset):
     assert len(dataset_slices) == 1
     assert slc.slice_id == dataset_slices[0]
 
-    response = slc.info()
-    assert response["name"] == TEST_SLICE_NAME
-    assert response["dataset_id"] == dataset.id
-    assert len(response["dataset_items"]) == 2
+    assert slc.name == TEST_SLICE_NAME
+    assert slc.dataset_id == dataset.id
+
+    items = slc.items
+    assert len(items) == 2
     for item in ds_items[:2]:
         assert (
-            item.reference_id == response["dataset_items"][0]["ref_id"]
-            or item.reference_id == response["dataset_items"][1]["ref_id"]
+            item.reference_id == items[0]["ref_id"]
+            or item.reference_id == items[1]["ref_id"]
         )
 
-    response = slc.summary()
+    response = slc.info()
     assert response["name"] == TEST_SLICE_NAME
+    assert response["slice_id"] == slc.slice_id
     assert response["dataset_id"] == dataset.id
 
 
@@ -136,13 +138,13 @@ def test_slice_append(dataset):
     # Insert duplicate first item
     slc.append(reference_ids=[item.reference_id for item in ds_items[:3]])
 
-    response = slc.info()
-    assert len(response["dataset_items"]) == 3
+    items = slc.items
+    assert len(items) == 3
     for item in ds_items[:3]:
         assert (
-            item.reference_id == response["dataset_items"][0]["ref_id"]
-            or item.reference_id == response["dataset_items"][1]["ref_id"]
-            or item.reference_id == response["dataset_items"][2]["ref_id"]
+            item.reference_id == items[0]["ref_id"]
+            or item.reference_id == items[1]["ref_id"]
+            or item.reference_id == items[2]["ref_id"]
         )
 
     all_stored_items = [_[ITEM_KEY] for _ in slc.items_and_annotations()]
@@ -182,8 +184,8 @@ def test_slice_send_to_labeling(dataset):
         reference_ids=[ds_items[0].reference_id, ds_items[1].reference_id],
     )
 
-    response = slc.info()
-    assert len(response["dataset_items"]) == 2
+    items = slc.items
+    assert len(items) == 2
 
     response = slc.send_to_labeling(TEST_PROJECT_ID)
     assert isinstance(response, AsyncJob)


### PR DESCRIPTION
* Add `Slice.name`
* Add `Slice.items`
* Speed up `Slice.info` by not fetching Slice items
* Deprecate `NucleusClient.slice_info` in favor of `Slice.info`
    * Remove the latter's dependency on the request in the former
* Minor docs fix

I'm open to suggestions on the method name! If not many users depend on `Slice.info`, we can maybe have that be the new endpoint for short form info. Then we just have to warn users that if they want items, they have to use `Slice.items_and_annotations`. (This will result in a major cascade of unit test changes though, which all depend on `Slice.info` fetching items).

Docs autodeploy: https://scale-ai-nucleus-python-sdk--180.com.readthedocs.build/en/180/api/nucleus/index.html#nucleus.Slice.summary