### PR TITLE
Skip Failing ModelCi Tests

### DIFF
--- a/tests/modelci/conftest.py
+++ b/tests/modelci/conftest.py
@@ -64,11 +64,11 @@ def predictions(model, modelci_dataset, annotations):
     yield predictions
 
 
-@pytest.mark.skip("Assigned slice has no 2D annotations")
-@pytest.fixture(scope="module")
-@pytest.mark.usefixtures(
-    "annotations"
-)  # Unit test needs to have annotations in the slice
+# Skip test since the assigned slice has no 2D annotations
+# @pytest.fixture(scope="module")
+# @pytest.mark.usefixtures(
+#     "annotations"
+# )  # Unit test needs to have annotations in the slice
 def unit_test(CLIENT, test_slice):
     test_name = "unit_test_" + get_uuid()  # use uuid to make unique
     unit_test = CLIENT.modelci.create_unit_test(

--- a/tests/modelci/conftest.py
+++ b/tests/modelci/conftest.py
@@ -64,6 +64,7 @@ def predictions(model, modelci_dataset, annotations):
     yield predictions
 
 
+@pytest.mark.skip("Assigned slice has no 2D annotations")
 @pytest.fixture(scope="module")
 @pytest.mark.usefixtures(
     "annotations"

--- a/tests/modelci/conftest.py
+++ b/tests/modelci/conftest.py
@@ -64,11 +64,10 @@ def predictions(model, modelci_dataset, annotations):
     yield predictions
 
 
-# Skip test since the assigned slice has no 2D annotations
-# @pytest.fixture(scope="module")
-# @pytest.mark.usefixtures(
-#     "annotations"
-# )  # Unit test needs to have annotations in the slice
+@pytest.fixture(scope="module")
+@pytest.mark.usefixtures(
+    "annotations"
+)  # Unit test needs to have annotations in the slice
 def unit_test(CLIENT, test_slice):
     test_name = "unit_test_" + get_uuid()  # use uuid to make unique
     unit_test = CLIENT.modelci.create_unit_test(

--- a/tests/modelci/test_unit_test.py
+++ b/tests/modelci/test_unit_test.py
@@ -23,6 +23,7 @@ def test_unit_test_metric_creation(CLIENT, unit_test):
     assert unit_test_metric in criteria
 
 
+@pytest.mark.skip("Assigned slice has no 2D annotations")
 def test_list_unit_test(CLIENT, test_slice):
     test_name = "unit_test_" + get_uuid()  # use uuid to make unique
 

--- a/tests/modelci/test_unit_test.py
+++ b/tests/modelci/test_unit_test.py
@@ -9,6 +9,7 @@ from tests.helpers import (
 )
 
 
+@pytest.mark.skip("Assigned slice has no 2D annotations")
 def test_unit_test_metric_creation(CLIENT, unit_test):
     # create some dataset_items for the unit test to reference
     iou = CLIENT.modelci.eval_functions.bbox_iou

--- a/tests/modelci/test_unit_test_evaluation.py
+++ b/tests/modelci/test_unit_test_evaluation.py
@@ -9,6 +9,7 @@ from tests.helpers import EVAL_FUNCTION_THRESHOLD, get_uuid
 from tests.modelci.helpers import create_predictions
 
 
+@pytest.mark.skip("Assigned slice has no 2D annotations")
 @pytest.mark.integration
 def test_unit_test_evaluation(
     CLIENT, modelci_dataset, model, unit_test, annotations, predictions


### PR DESCRIPTION
Due to https://github.com/scaleapi/scaleapi/pull/33821 some of the tests are invalid. Skipping them until we can update them.