### PR TITLE
Add basic polygon metrics to nucleus repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   build_test:
     docker:
-      - image: python:3.6-buster
+      - image: python:3.7-buster
     resource_class: small
     parallelism: 6
     steps:
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Black Formatting Check # Only validation, without re-formatting
           command: |
-            poetry run black --check -t py36 .
+            poetry run black --check -t py37 .
       - run:
           name: Flake8 Lint Check # Uses setup.cfg for configuration
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-07
+## [0.5.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.5.0) - 2021-01-10
+
+### Added
+- `nucleus.metrics` module for computing metrics between Nucleus `Annotation` and `Prediction` objects.
+
+## [0.4.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.5) - 2021-01-07
 
 ### Added
 - `Dataset.scenes` property that fetches the Scale-generated ID, reference ID, type, and metadata of all scenes in the Dataset.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Sections
    :maxdepth: 4
 
    api/nucleus/index
+   api/nucleus/metrics/index
    api/nucleus/modelci/index
 
 

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Sequence, Union
 from urllib.parse import urlparse
@@ -593,6 +593,56 @@ class MultiCategoryAnnotation(Annotation):
         if self.taxonomy_name is not None:
             payload[TAXONOMY_NAME_KEY] = self.taxonomy_name
         return payload
+
+
+@dataclass
+class AnnotationList:
+    """Wrapper class separating a list of annotations by type."""
+
+    box_annotations: List[BoxAnnotation] = field(default_factory=list)
+    polygon_annotations: List[PolygonAnnotation] = field(default_factory=list)
+    cuboid_annotations: List[CuboidAnnotation] = field(default_factory=list)
+    category_annotations: List[CategoryAnnotation] = field(
+        default_factory=list
+    )
+    multi_category_annotations: List[MultiCategoryAnnotation] = field(
+        default_factory=list
+    )
+    segmentation_annotations: List[SegmentationAnnotation] = field(
+        default_factory=list
+    )
+
+    def add_annotations(self, annotations: List[Annotation]):
+        for annotation in annotations:
+            assert isinstance(
+                annotation, Annotation
+            ), "Expected annotation to be of type 'Annotation"
+
+            if isinstance(annotation, BoxAnnotation):
+                self.box_annotations.append(annotation)
+            elif isinstance(annotation, PolygonAnnotation):
+                self.polygon_annotations.append(annotation)
+            elif isinstance(annotation, CuboidAnnotation):
+                self.cuboid_annotations.append(annotation)
+            elif isinstance(annotation, CategoryAnnotation):
+                self.category_annotations.append(annotation)
+            elif isinstance(annotation, MultiCategoryAnnotation):
+                self.multi_category_annotations.append(annotation)
+            else:
+                assert isinstance(
+                    annotation, SegmentationAnnotation
+                ), f"Unexpected annotation type: {type(annotation)}"
+                self.segmentation_annotations.append(annotation)
+
+    def __len__(self):
+        return (
+            len(self.box_annotations)
+            + len(self.polygon_annotations)
+            + len(self.cuboid_annotations)
+            + len(self.category_annotations)
+            + len(self.multi_category_annotations)
+            + len(self.segmentation_annotations)
+        )
 
 
 def is_local_path(path: str) -> bool:

--- a/nucleus/metrics/__init__.py
+++ b/nucleus/metrics/__init__.py
@@ -1,0 +1,7 @@
+from .base import MetricResult
+from .polygon_metrics import (
+    PolygonIOU,
+    PolygonMetric,
+    PolygonPrecision,
+    PolygonRecall,
+)

--- a/nucleus/metrics/__init__.py
+++ b/nucleus/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .base import MetricResult
+from .base import Metric, MetricResult
 from .polygon_metrics import (
     PolygonIOU,
     PolygonMetric,

--- a/nucleus/metrics/base.py
+++ b/nucleus/metrics/base.py
@@ -21,7 +21,7 @@ class MetricResult:
     """
 
     value: float
-    weight: float = 1
+    weight: float = 1.0
 
     @staticmethod
     def aggregate(results: Iterable["MetricResult"]) -> "MetricResult":

--- a/nucleus/metrics/base.py
+++ b/nucleus/metrics/base.py
@@ -11,7 +11,7 @@ AnnotationOrPredictionList = Union[List[Annotation], List[Prediction]]
 
 @dataclass
 class MetricResult:
-    """An Metric Result contains the value of an evaluation, as well as its weight.
+    """A Metric Result contains the value of an evaluation, as well as its weight.
     The weight is useful when aggregating metrics where each dataset item may hold a
     different relative weight. For example, when calculating precision over a dataset,
     the denominator of the precision is the number of annotations, and therefore the weight

--- a/nucleus/metrics/base.py
+++ b/nucleus/metrics/base.py
@@ -1,12 +1,10 @@
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Iterable, List, Union
+from typing import Iterable
 
-from nucleus.annotation import Annotation
-from nucleus.prediction import Prediction
-
-AnnotationOrPredictionList = Union[List[Annotation], List[Prediction]]
+from nucleus.annotation import AnnotationList
+from nucleus.prediction import PredictionList
 
 
 @dataclass
@@ -25,47 +23,67 @@ class MetricResult:
     value: float
     weight: float = 1
 
-    @classmethod
-    def aggregate(cls, results: Iterable["MetricResult"]) -> "MetricResult":
+    @staticmethod
+    def aggregate(results: Iterable["MetricResult"]) -> "MetricResult":
         """Aggregates results using a weighted average."""
         results = list(filter(lambda x: x.weight != 0, results))
         total_weight = sum([result.weight for result in results])
         total_value = sum([result.value * result.weight for result in results])
         value = total_value / max(total_weight, sys.float_info.epsilon)
-        return cls(value, total_weight)
+        return MetricResult(value, total_weight)
 
 
 class Metric(ABC):
-    """Abstract class to define a Metric."""
+    """Abstract class for defining a metric, which takes a list of annotations
+    and predictions and returns a scalar.
+
+    To create a new concrete Metric, override the `__call__` function
+    with logic to define a metric between annotations and predictions. ::
+
+        from nucleus import BoxAnnotation, CuboidPrediction, Point3D
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import Metric, MetricResult
+        from nucleus.metrics.polygon_utils import BoxOrPolygonAnnotation, BoxOrPolygonPrediction
+
+        class MyMetric(Metric):
+            def __call__(
+                self, annotations: AnnotationList, predictions: PredictionList
+            ) -> MetricResult:
+                value = (len(annotations) - len(predictions)) ** 2
+                weight = len(annotations)
+                return MetricResult(value, weight)
+
+        box = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        cuboid = CuboidPrediction(
+            label="car",
+            position=Point3D(100, 100, 10),
+            dimensions=Point3D(5, 10, 5),
+            yaw=0,
+            reference_id="pointcloud_1",
+            confidence=0.8,
+            annotation_id="pointcloud_1_car_cuboid_1",
+            metadata={"vehicle_color": "green"}
+        )
+
+        metric = MyMetric()
+        annotations = AnnotationList(box_annotations=[box])
+        predictions = PredictionList(cuboid_predictions=[cuboid])
+        metric(annotations, predictions)
+    """
 
     @abstractmethod
     def __call__(
-        self, annotations: List[Annotation], predictions: List[Prediction]
+        self, annotations: AnnotationList, predictions: PredictionList
     ) -> MetricResult:
         """A metric must override this method and return a metric result, given annotations and predictions."""
-
-
-class Filter(ABC):
-    """Abstract class to define an Filter"""
-
-    @abstractmethod
-    def __call__(
-        self, annotations: AnnotationOrPredictionList
-    ) -> AnnotationOrPredictionList:
-        """A Filter must override this method."""
-
-
-class AnnotationFilter(ABC):
-    """Abstract class to define an Filter"""
-
-    @abstractmethod
-    def __call__(self, annotations: List[Annotation]) -> List[Annotation]:
-        """An Annotation Filter must override this method."""
-
-
-class PredictionFilter(ABC):
-    """Abstract class to define an Prediction Filter"""
-
-    @abstractmethod
-    def __call__(self, predictions: List[Prediction]) -> List[Prediction]:
-        """An Prediction Filter must override this method."""

--- a/nucleus/metrics/base.py
+++ b/nucleus/metrics/base.py
@@ -1,0 +1,71 @@
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, List, Union
+
+from nucleus.annotation import Annotation
+from nucleus.prediction import Prediction
+
+AnnotationOrPredictionList = Union[List[Annotation], List[Prediction]]
+
+
+@dataclass
+class MetricResult:
+    """An Metric Result contains the value of an evaluation, as well as its weight.
+    The weight is useful when aggregating metrics where each dataset item may hold a
+    different relative weight. For example, when calculating precision over a dataset,
+    the denominator of the precision is the number of annotations, and therefore the weight
+    can be set as the number of annotations.
+
+    Attributes:
+        value (float): The value of the evaluation result
+        weight (float): The weight of the evaluation result.
+    """
+
+    value: float
+    weight: float = 1
+
+    @classmethod
+    def aggregate(cls, results: Iterable["MetricResult"]) -> "MetricResult":
+        """Aggregates results using a weighted average."""
+        results = list(filter(lambda x: x.weight != 0, results))
+        total_weight = sum([result.weight for result in results])
+        total_value = sum([result.value * result.weight for result in results])
+        value = total_value / max(total_weight, sys.float_info.epsilon)
+        return cls(value, total_weight)
+
+
+class Metric(ABC):
+    """Abstract class to define a Metric."""
+
+    @abstractmethod
+    def __call__(
+        self, annotations: List[Annotation], predictions: List[Prediction]
+    ) -> MetricResult:
+        """A metric must override this method and return a metric result, given annotations and predictions."""
+
+
+class Filter(ABC):
+    """Abstract class to define an Filter"""
+
+    @abstractmethod
+    def __call__(
+        self, annotations: AnnotationOrPredictionList
+    ) -> AnnotationOrPredictionList:
+        """A Filter must override this method."""
+
+
+class AnnotationFilter(ABC):
+    """Abstract class to define an Filter"""
+
+    @abstractmethod
+    def __call__(self, annotations: List[Annotation]) -> List[Annotation]:
+        """An Annotation Filter must override this method."""
+
+
+class PredictionFilter(ABC):
+    """Abstract class to define an Prediction Filter"""
+
+    @abstractmethod
+    def __call__(self, predictions: List[Prediction]) -> List[Prediction]:
+        """An Prediction Filter must override this method."""

--- a/nucleus/metrics/errors.py
+++ b/nucleus/metrics/errors.py
@@ -1,0 +1,7 @@
+class PolygonAnnotationTypeError(Exception):
+    def __init__(
+        self,
+        message="Annotation was expected to be type BoxAnnotation or PolygonAnnotation.",
+    ):
+        self.message = message
+        super().__init__(self.message)

--- a/nucleus/metrics/errors.py
+++ b/nucleus/metrics/errors.py
@@ -1,7 +1,7 @@
 class PolygonAnnotationTypeError(Exception):
     def __init__(
         self,
-        message="Annotation was expected to be type BoxAnnotation or PolygonAnnotation.",
+        message="Annotation was expected to be of type 'BoxAnnotation' or 'PolygonAnnotation'.",
     ):
         self.message = message
         super().__init__(self.message)

--- a/nucleus/metrics/filters.py
+++ b/nucleus/metrics/filters.py
@@ -24,19 +24,8 @@ def confidence_filter(
         lambda prediction: not hasattr(prediction, "confidence")
         or prediction.confidence >= min_confidence
     )
-    predictions_copy.box_predictions = list(
-        filter(filter_fn, predictions.box_predictions)
-    )
-    predictions_copy.polygon_predictions = list(
-        filter(filter_fn, predictions.polygon_predictions)
-    )
-    predictions_copy.cuboid_predictions = list(
-        filter(filter_fn, predictions.cuboid_predictions)
-    )
-    predictions_copy.category_predictions = list(
-        filter(filter_fn, predictions.category_predictions)
-    )
-    predictions_copy.segmentation_predictions = list(
-        filter(filter_fn, predictions.segmentation_predictions)
-    )
+    for attr in predictions.__dict__:
+        predictions_copy.__dict__[attr] = list(
+            filter(filter_fn, predictions.__dict__[attr])
+        )
     return predictions_copy

--- a/nucleus/metrics/filters.py
+++ b/nucleus/metrics/filters.py
@@ -1,48 +1,42 @@
-from typing import List, Tuple
+from typing import List
 
-from nucleus.annotation import Annotation
-from nucleus.prediction import Prediction
+from nucleus.prediction import PredictionList
 
-from .base import AnnotationOrPredictionList, Filter, PredictionFilter
-from .polygon_utils import BoxOrPolygonAnnotation, _polygon_annotation_to_shape
+from .polygon_utils import BoxOrPolygonAnnotation, polygon_annotation_to_shape
 
 
-class TypeFilter(Filter):
-    """Filters annotations and predictions by type (e.g. Box, Polygon, Cuboid)."""
-
-    def __init__(self, types: Tuple[type, ...]):
-        assert all(issubclass(typ, Annotation) for typ in types)
-        self.filter_fn = lambda x: isinstance(x, types)
-
-    def __call__(
-        self, annotations: AnnotationOrPredictionList
-    ) -> AnnotationOrPredictionList:
-        return list(filter(self.filter_fn, annotations))
+def polygon_area_filter(
+    polygons: List[BoxOrPolygonAnnotation], min_area: float, max_area: float
+) -> List[BoxOrPolygonAnnotation]:
+    filter_fn = (
+        lambda polygon: min_area
+        <= polygon_annotation_to_shape(polygon)
+        <= max_area
+    )
+    return list(filter(filter_fn, polygons))
 
 
-class PolygonAreaFilter(Filter):
-    """Filters polygon annotations and predictions by area."""
-
-    def __init__(self, min_area: float, max_area: float):
-        self.min_area = min_area
-        self.max_area = max_area
-
-    def filter_fn(self, annotation: BoxOrPolygonAnnotation):
-        area = _polygon_annotation_to_shape(annotation).area
-        return self.min_area <= area <= self.max_area
-
-    def __call__(self, annotations: List[BoxOrPolygonAnnotation]) -> List[BoxOrPolygonAnnotation]:  # type: ignore[override]
-        return list(filter(self.filter_fn, annotations))
-
-
-class ConfidenceFilter(PredictionFilter):
-    """Filters predictions by confidence score."""
-
-    def __init__(self, min_confidence: float):
-        assert (
-            0 <= min_confidence <= 1
-        ), "Min confidence must be between 0 and 1."
-        self.filter_fn = lambda x: x.confidence >= min_confidence
-
-    def __call__(self, predictions: List[Prediction]) -> List[Prediction]:
-        return list(filter(self.filter_fn, predictions))
+def confidence_filter(
+    predictions: PredictionList, min_confidence: float
+) -> PredictionList:
+    predictions_copy = PredictionList()
+    filter_fn = (
+        lambda prediction: not hasattr(prediction, "confidence")
+        or prediction.confidence >= min_confidence
+    )
+    predictions_copy.box_predictions = list(
+        filter(filter_fn, predictions.box_predictions)
+    )
+    predictions_copy.polygon_predictions = list(
+        filter(filter_fn, predictions.polygon_predictions)
+    )
+    predictions_copy.cuboid_predictions = list(
+        filter(filter_fn, predictions.cuboid_predictions)
+    )
+    predictions_copy.category_predictions = list(
+        filter(filter_fn, predictions.category_predictions)
+    )
+    predictions_copy.segmentation_predictions = list(
+        filter(filter_fn, predictions.segmentation_predictions)
+    )
+    return predictions_copy

--- a/nucleus/metrics/filters.py
+++ b/nucleus/metrics/filters.py
@@ -1,0 +1,48 @@
+from typing import List, Tuple
+
+from nucleus.annotation import Annotation
+from nucleus.prediction import Prediction
+
+from .base import AnnotationOrPredictionList, Filter, PredictionFilter
+from .polygon_utils import BoxOrPolygonAnnotation, _polygon_annotation_to_shape
+
+
+class TypeFilter(Filter):
+    """Filters annotations and predictions by type (e.g. Box, Polygon, Cuboid)."""
+
+    def __init__(self, types: Tuple[type, ...]):
+        assert all(issubclass(typ, Annotation) for typ in types)
+        self.filter_fn = lambda x: isinstance(x, types)
+
+    def __call__(
+        self, annotations: AnnotationOrPredictionList
+    ) -> AnnotationOrPredictionList:
+        return list(filter(self.filter_fn, annotations))
+
+
+class PolygonAreaFilter(Filter):
+    """Filters polygon annotations and predictions by area."""
+
+    def __init__(self, min_area: float, max_area: float):
+        self.min_area = min_area
+        self.max_area = max_area
+
+    def filter_fn(self, annotation: BoxOrPolygonAnnotation):
+        area = _polygon_annotation_to_shape(annotation).area
+        return self.min_area <= area <= self.max_area
+
+    def __call__(self, annotations: List[BoxOrPolygonAnnotation]) -> List[BoxOrPolygonAnnotation]:  # type: ignore[override]
+        return list(filter(self.filter_fn, annotations))
+
+
+class ConfidenceFilter(PredictionFilter):
+    """Filters predictions by confidence score."""
+
+    def __init__(self, min_confidence: float):
+        assert (
+            0 <= min_confidence <= 1
+        ), "Min confidence must be between 0 and 1."
+        self.filter_fn = lambda x: x.confidence >= min_confidence
+
+    def __call__(self, predictions: List[Prediction]) -> List[Prediction]:
+        return list(filter(self.filter_fn, predictions))

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -109,6 +109,7 @@ class PolygonMetric(Metric):
 class PolygonIOU(PolygonMetric):
     """Calculates the average IOU between box or polygon annotations and predictions."""
 
+    # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
         self,
         enforce_label_match: bool = False,
@@ -144,6 +145,7 @@ class PolygonIOU(PolygonMetric):
 class PolygonPrecision(PolygonMetric):
     """Calculates the precision between box or polygon annotations and predictions."""
 
+    # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
         self,
         enforce_label_match: bool = False,
@@ -180,6 +182,7 @@ class PolygonPrecision(PolygonMetric):
 class PolygonRecall(PolygonMetric):
     """Calculates the recall between box or polygon annotations and predictions."""
 
+    # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
         self,
         enforce_label_match: bool = False,

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -1,9 +1,9 @@
 import sys
 from abc import abstractmethod
-from typing import List
+from typing import List, Union
 
-from nucleus.annotation import AnnotationList
-from nucleus.prediction import PredictionList
+from nucleus.annotation import AnnotationList, BoxAnnotation, PolygonAnnotation
+from nucleus.prediction import BoxPrediction, PolygonPrediction, PredictionList
 
 from .base import Metric, MetricResult
 from .filters import confidence_filter
@@ -90,10 +90,10 @@ class PolygonMetric(Metric):
             predictions = confidence_filter(
                 predictions, self.confidence_threshold
             )
-        polygon_annotations: List[BoxOrPolygonAnnotation] = []
+        polygon_annotations: List[Union[BoxAnnotation, PolygonAnnotation]] = []
         polygon_annotations.extend(annotations.box_annotations)
         polygon_annotations.extend(annotations.polygon_annotations)
-        polygon_predictions: List[BoxOrPolygonAnnotation] = []
+        polygon_predictions: List[Union[BoxPrediction, PolygonPrediction]] = []
         polygon_predictions.extend(predictions.box_predictions)
         polygon_predictions.extend(predictions.polygon_predictions)
 

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -1,0 +1,212 @@
+import sys
+from abc import abstractmethod
+from typing import List
+
+from nucleus.annotation import Annotation, BoxAnnotation, PolygonAnnotation
+from nucleus.prediction import Prediction
+
+from .base import Metric, MetricResult
+from .filters import ConfidenceFilter, TypeFilter
+from .polygon_utils import (
+    BoxOrPolygonAnnotation,
+    BoxOrPolygonPrediction,
+    iou_assignments,
+    label_match_wrapper,
+    num_true_positives,
+)
+
+
+class PolygonMetric(Metric):
+    """Abstract class for metrics of box and polygons.
+
+    The PolygonMetric class automatically filters incoming annotations and
+    predictions for only box and polygon annotations. It also filters
+    predictions whose confidence is less than the provided confidence_threshold.
+    Finally, it provides support for enforcing matching labels. If
+    `enforce_label_match` is set to True, then annotations and predictions will
+    only be matched if they have the same label.
+
+    To create a new concrete PolygonMetric, override the `eval` function
+    with logic to define a metric between box/polygon annotations and predictions.
+    For example, ::
+
+        from nucleus import BoxAnnotation
+        from nucleus.metrics import MetricResult, PolygonMetric
+        from nucleus.metrics.polygon_utils import BoxOrPolygonAnnotation, BoxOrPolygonPrediction
+
+        class MyPolygonMetric(PolygonMetric):
+            def eval(
+                self,
+                annotations: List[BoxOrPolygonAnnotation],
+                predictions: List[BoxOrPolygonPrediction],
+            ) -> MetricResult:
+                value = (len(annotations) - len(predictions)) ** 2
+                weight = len(annotations)
+                return MetricResult(value, weight)
+
+        box = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        metric = MyPolygonMetric()
+        metric([box], [box])
+    """
+
+    def __init__(
+        self,
+        enforce_label_match: bool = False,
+        confidence_threshold: float = 0.0,
+    ):
+        """Initializes PolygonMetric abstract object.
+
+        Args:
+            enforce_label_match: whether to enforce that annotation and prediction labels must match. Default False
+            confidence_threshold: minimum confidence threshold for predictions. Must be in [0, 1]. Default 0.0
+        """
+        self.polygon_filter = TypeFilter((BoxAnnotation, PolygonAnnotation))
+        self.enforce_label_match = enforce_label_match
+        self.confidence_filter = None
+        assert (
+            0 <= confidence_threshold <= 1
+        ), "Confidence threshold must be between 0 and 1."
+        if confidence_threshold > 0:
+            self.confidence_filter = ConfidenceFilter(confidence_threshold)
+
+    @abstractmethod
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        # Main evaluation function that subclasses must override.
+        pass
+
+    def __call__(
+        self, annotations: List[Annotation], predictions: List[Prediction]
+    ) -> MetricResult:
+        if self.confidence_filter:
+            predictions = self.confidence_filter(predictions)
+        polygon_annotations = self.polygon_filter(annotations)
+        polygon_predictions = self.polygon_filter(predictions)
+
+        eval_fn = label_match_wrapper(self.eval)
+        result = eval_fn(
+            polygon_annotations,
+            polygon_predictions,
+            enforce_label_match=self.enforce_label_match,
+        )
+        return result
+
+
+class PolygonIOU(PolygonMetric):
+    """Calculates the average IOU between box or polygon annotations and predictions."""
+
+    def __init__(
+        self,
+        enforce_label_match: bool = False,
+        iou_threshold: float = 0.0,
+        confidence_threshold: float = 0.0,
+    ):
+        """Initializes PolygonIOU object.
+
+        Args:
+            enforce_label_match: whether to enforce that annotation and prediction labels must match. Defaults to False
+            iou_threshold: IOU threshold to consider detection as valid. Must be in [0, 1]. Default 0.0
+            confidence_threshold: minimum confidence threshold for predictions. Must be in [0, 1]. Default 0.0
+        """
+        assert (
+            0 <= iou_threshold <= 1
+        ), "IoU threshold must be between 0 and 1."
+        self.iou_threshold = iou_threshold
+        super().__init__(enforce_label_match, confidence_threshold)
+
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        iou_assigns = iou_assignments(
+            annotations, predictions, self.iou_threshold
+        )
+        weight = max(len(annotations), len(predictions))
+        avg_iou = iou_assigns.sum() / max(weight, sys.float_info.epsilon)
+        return MetricResult(avg_iou, weight)
+
+
+class PolygonPrecision(PolygonMetric):
+    """Calculates the precision between box or polygon annotations and predictions."""
+
+    def __init__(
+        self,
+        enforce_label_match: bool = False,
+        iou_threshold: float = 0.5,
+        confidence_threshold: float = 0.0,
+    ):
+        """Initializes PolygonPrecision object.
+
+        Args:
+            enforce_label_match: whether to enforce that annotation and prediction labels must match. Defaults to False
+            iou_threshold: IOU threshold to consider detection as valid. Must be in [0, 1]. Default 0.5
+            confidence_threshold: minimum confidence threshold for predictions. Must be in [0, 1]. Default 0.0
+        """
+        assert (
+            0 <= iou_threshold <= 1
+        ), "IoU threshold must be between 0 and 1."
+        self.iou_threshold = iou_threshold
+        super().__init__(enforce_label_match, confidence_threshold)
+
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        true_positives = num_true_positives(
+            annotations, predictions, self.iou_threshold
+        )
+        weight = len(predictions)
+        return MetricResult(
+            true_positives / max(weight, sys.float_info.epsilon), weight
+        )
+
+
+class PolygonRecall(PolygonMetric):
+    """Calculates the recall between box or polygon annotations and predictions."""
+
+    def __init__(
+        self,
+        enforce_label_match: bool = False,
+        iou_threshold: float = 0.5,
+        confidence_threshold: float = 0.0,
+    ):
+        """Initializes PolygonRecall object.
+
+        Args:
+            enforce_label_match: whether to enforce that annotation and prediction labels must match. Defaults to False
+            iou_threshold: IOU threshold to consider detection as valid. Must be in [0, 1]. Default 0.5
+            confidence_threshold: minimum confidence threshold for predictions. Must be in [0, 1]. Default 0.0
+        """
+        assert (
+            0 <= iou_threshold <= 1
+        ), "IoU threshold must be between 0 and 1."
+        self.iou_threshold = iou_threshold
+        super().__init__(enforce_label_match, confidence_threshold)
+
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        true_positives = num_true_positives(
+            annotations, predictions, self.iou_threshold
+        )
+        weight = len(annotations) + sys.float_info.epsilon
+        return MetricResult(
+            true_positives / max(weight, sys.float_info.epsilon), weight
+        )

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -18,7 +18,7 @@ BoxOrPolygonAnnotation = Union[
 ]
 
 
-def _polygon_annotation_to_shape(
+def polygon_annotation_to_shape(
     annotation: BoxOrPolygonAnnotation,
 ) -> Polygon:
     if isinstance(annotation, BoxAnnotation):
@@ -64,8 +64,8 @@ def _iou_assignments_for_same_reference_id(
     ), "Expected annotations and predictions to have same reference ID."
 
     # Convert annotation and predictions to shapely.geometry.Polygon objects
-    polygon_annotations = list(map(_polygon_annotation_to_shape, annotations))
-    polygon_predictions = list(map(_polygon_annotation_to_shape, predictions))
+    polygon_annotations = list(map(polygon_annotation_to_shape, annotations))
+    polygon_predictions = list(map(polygon_annotation_to_shape, predictions))
 
     # Compute IoU matrix and set IoU values below the threshold to 0.
     iou_matrix = _iou_matrix(polygon_annotations, polygon_predictions)

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -1,0 +1,230 @@
+import sys
+from functools import wraps
+from typing import Dict, List, Tuple, Union
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+from shapely.geometry import Polygon
+
+from nucleus.annotation import BoxAnnotation, PolygonAnnotation
+from nucleus.prediction import BoxPrediction, PolygonPrediction
+
+from .base import MetricResult
+from .errors import PolygonAnnotationTypeError
+
+BoxOrPolygonPrediction = Union[BoxPrediction, PolygonPrediction]
+BoxOrPolygonAnnotation = Union[
+    BoxAnnotation, PolygonAnnotation, BoxOrPolygonPrediction
+]
+
+
+def _polygon_annotation_to_shape(
+    annotation: BoxOrPolygonAnnotation,
+) -> Polygon:
+    if isinstance(annotation, BoxAnnotation):
+        xmin = annotation.x - annotation.width / 2
+        xmax = annotation.x + annotation.width / 2
+        ymin = annotation.y - annotation.height / 2
+        ymax = annotation.y + annotation.height / 2
+        return Polygon(
+            [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)]
+        )
+    elif isinstance(annotation, PolygonAnnotation):
+        return Polygon([(point.x, point.y) for point in annotation.vertices])
+    else:
+        raise PolygonAnnotationTypeError()
+
+
+def _iou(annotation: Polygon, prediction: Polygon) -> float:
+    intersection = annotation.intersection(prediction).area
+    union = annotation.area + prediction.area - intersection
+    return intersection / max(union, sys.float_info.epsilon)
+
+
+def _iou_matrix(
+    annotations: List[Polygon], predictions: List[Polygon]
+) -> np.ndarray:
+    iou_matrix = np.empty((len(predictions), len(annotations)))
+    for i, prediction in enumerate(predictions):
+        for j, annotation in enumerate(annotations):
+            iou_matrix[i, j] = _iou(annotation, prediction)
+    return iou_matrix
+
+
+def _iou_assignments_for_same_reference_id(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+    iou_threshold: float,
+) -> np.ndarray:
+    # Check that all annotations and predictions have same reference ID.
+    reference_ids = set(annotation.reference_id for annotation in annotations)
+    reference_ids |= set(prediction.reference_id for prediction in predictions)
+    assert (
+        len(reference_ids) <= 1
+    ), "Expected annotations and predictions to have same reference ID."
+
+    # Convert annotation and predictions to shapely.geometry.Polygon objects
+    polygon_annotations = list(map(_polygon_annotation_to_shape, annotations))
+    polygon_predictions = list(map(_polygon_annotation_to_shape, predictions))
+
+    # Compute IoU matrix and set IoU values below the threshold to 0.
+    iou_matrix = _iou_matrix(polygon_annotations, polygon_predictions)
+    iou_matrix[iou_matrix < iou_threshold] = 0
+
+    # Match annotations and predictions using linear sum assignment and filter out
+    # values below the threshold.
+    matched_0, matched_1 = linear_sum_assignment(-iou_matrix)
+    iou_assigns = iou_matrix[matched_0, matched_1]
+    iou_assigns = iou_assigns[iou_assigns >= iou_threshold]
+    return iou_assigns
+
+
+def group_boxes_or_polygons_by_reference_id(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+) -> Dict[
+    str, Tuple[List[BoxOrPolygonAnnotation], List[BoxOrPolygonPrediction]]
+]:
+    """Groups input annotations and predictions by reference_id.
+
+    Args:
+        annotations: list of input annotations
+        predictions: list of input predictions
+
+    Returns:
+        Mapping from each reference_id to (annotations, predictions) tuple.
+    """
+    reference_ids = set(annotation.reference_id for annotation in annotations)
+    reference_ids |= set(prediction.reference_id for prediction in predictions)
+    grouped: Dict[
+        str, Tuple[List[BoxOrPolygonAnnotation], List[BoxOrPolygonPrediction]]
+    ] = {reference_id: ([], []) for reference_id in reference_ids}
+    for annotation in annotations:
+        grouped[annotation.reference_id][0].append(annotation)
+    for prediction in predictions:
+        grouped[prediction.reference_id][1].append(prediction)
+    return grouped
+
+
+def group_boxes_or_polygons_by_label(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+) -> Dict[
+    str, Tuple[List[BoxOrPolygonAnnotation], List[BoxOrPolygonPrediction]]
+]:
+    """Groups input annotations and predictions by label.
+
+    Args:
+        annotations: list of input box or polygon annotations
+        predictions: list of input box or polygon predictions
+
+    Returns:
+        Mapping from each label to (annotations, predictions) tuple
+    """
+    labels = set(annotation.label for annotation in annotations)
+    labels |= set(prediction.label for prediction in predictions)
+    grouped: Dict[
+        str, Tuple[List[BoxOrPolygonAnnotation], List[BoxOrPolygonPrediction]]
+    ] = {label: ([], []) for label in labels}
+    for annotation in annotations:
+        grouped[annotation.label][0].append(annotation)
+    for prediction in predictions:
+        grouped[prediction.label][1].append(prediction)
+    return grouped
+
+
+def iou_assignments(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+    iou_threshold: float,
+) -> np.ndarray:
+    """Matches annotations and predictions based on linear sum cost and returns the
+    intersection-over-union values of the matched annotation-prediction pairs, subject
+    to the specified IoU threshold. Note that annotations and predictions from
+    different reference_ids will not be matched with one another.
+    See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linear_sum_assignment.html
+
+    Args:
+        annotations: list of box or polygon annotations
+        predictions: list of box or polygon predictions
+        iou_threshold: the intersection-over-union threshold for an
+            annotation-prediction pair to be considered a match.
+
+    Returns:
+        1D numpy array that contains the IoU values of the matched pairs.
+    """
+    grouped_inputs = group_boxes_or_polygons_by_reference_id(
+        annotations, predictions
+    )
+    iou_assigns = []
+    for grouped_annotations, grouped_predictions in grouped_inputs.values():
+        result_per_reference_id = _iou_assignments_for_same_reference_id(
+            grouped_annotations, grouped_predictions, iou_threshold
+        )
+        iou_assigns.append(result_per_reference_id)
+    return np.concatenate(iou_assigns)
+
+
+def num_true_positives(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+    iou_threshold: float,
+) -> int:
+    """Counts the number of annotations with a matching prediction.
+
+    A prediction is considered a match for an annotation if it has not yet been
+    matched to another annotation, its reference_id is the same as the
+    annotation, and its IoU with the annotation is at least the iou_threshold.
+
+    Args:
+        annotations: list of box or polygon annotations
+        predictions: list of box or polygon predictions
+        iou_threshold: the intersection-over-union threshold for an
+            annotation-prediction pair to be considered a match.
+
+    Returns:
+        The number of true positives (predictions that are matched to annotations).
+    """
+    iou_assigns = iou_assignments(annotations, predictions, iou_threshold)
+    true_positives = len(iou_assigns)
+    return true_positives
+
+
+def label_match_wrapper(metric_fn):
+    """Decorator to add the ability to only apply metric to annotations and
+    predictions with matching labels.
+
+    Args:
+        metric_fn: Metric function that takes a list of annotations, a list
+            of predictions, and optional args and kwargs.
+
+    Returns:
+        Metric function which can optionally enforce matching labels.
+    """
+
+    @wraps(metric_fn)
+    def wrapper(
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+        *args,
+        enforce_label_match: bool = False,
+        **kwargs,
+    ) -> MetricResult:
+        # Simply return the metric if we are not enforcing label matches.
+        if not enforce_label_match:
+            return metric_fn(annotations, predictions, *args, **kwargs)
+
+        # For each bin of annotations/predictions, compute the metric applied
+        # only to that bin. Then aggregate results across all bins.
+        grouped_inputs = group_boxes_or_polygons_by_label(
+            annotations, predictions
+        )
+        metric_results = []
+        for binned_annotations, binned_predictions in grouped_inputs.values():
+            metric_result = metric_fn(
+                binned_annotations, binned_predictions, *args, **kwargs
+            )
+            metric_results.append(metric_result)
+        return MetricResult.aggregate(metric_results)
+
+    return wrapper

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -1,6 +1,6 @@
 import sys
 from functools import wraps
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, TypeVar
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -12,10 +12,12 @@ from nucleus.prediction import BoxPrediction, PolygonPrediction
 from .base import MetricResult
 from .errors import PolygonAnnotationTypeError
 
-BoxOrPolygonPrediction = Union[BoxPrediction, PolygonPrediction]
-BoxOrPolygonAnnotation = Union[
-    BoxAnnotation, PolygonAnnotation, BoxOrPolygonPrediction
-]
+BoxOrPolygonPrediction = TypeVar(
+    "BoxOrPolygonPrediction", BoxPrediction, PolygonPrediction
+)
+BoxOrPolygonAnnotation = TypeVar(
+    "BoxOrPolygonAnnotation", BoxAnnotation, PolygonAnnotation
+)
 
 
 def polygon_annotation_to_shape(

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -3,7 +3,7 @@ All of the prediction types supported. In general, prediction types are the same
 as annotation types, but come with additional, optional data that can be attached
 such as confidence or probability distributions.
 """
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from .annotation import (
     BoxAnnotation,
@@ -399,3 +399,8 @@ class CategoryPrediction(CategoryAnnotation):
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
         )
+
+
+Prediction = Union[
+    BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction
+]

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -3,6 +3,7 @@ All of the prediction types supported. In general, prediction types are the same
 as annotation types, but come with additional, optional data that can be attached
 such as confidence or probability distributions.
 """
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from .annotation import (
@@ -402,5 +403,49 @@ class CategoryPrediction(CategoryAnnotation):
 
 
 Prediction = Union[
-    BoxPrediction, PolygonPrediction, CuboidPrediction, SegmentationPrediction
+    BoxPrediction,
+    PolygonPrediction,
+    CuboidPrediction,
+    CategoryPrediction,
+    SegmentationPrediction,
 ]
+
+
+@dataclass
+class PredictionList:
+    """Wrapper class separating a list of predictions by type."""
+
+    box_predictions: List[BoxPrediction] = field(default_factory=list)
+    polygon_predictions: List[PolygonPrediction] = field(default_factory=list)
+    cuboid_predictions: List[CuboidPrediction] = field(default_factory=list)
+    category_predictions: List[CategoryPrediction] = field(
+        default_factory=list
+    )
+    segmentation_predictions: List[SegmentationPrediction] = field(
+        default_factory=list
+    )
+
+    def add_predictions(self, predictions: List[Prediction]):
+        for prediction in predictions:
+            if isinstance(prediction, BoxPrediction):
+                self.box_predictions.append(prediction)
+            elif isinstance(prediction, PolygonPrediction):
+                self.polygon_predictions.append(prediction)
+            elif isinstance(prediction, CuboidPrediction):
+                self.cuboid_predictions.append(prediction)
+            elif isinstance(prediction, CategoryPrediction):
+                self.category_predictions.append(prediction)
+            else:
+                assert isinstance(
+                    prediction, SegmentationPrediction
+                ), f"Unexpected prediction type: {type(prediction)}"
+                self.segmentation_predictions.append(prediction)
+
+    def __len__(self):
+        return (
+            len(self.box_predictions)
+            + len(self.polygon_predictions)
+            + len(self.cuboid_predictions)
+            + len(self.category_predictions)
+            + len(self.segmentation_predictions)
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.4.5"
+version = "0.5"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://dashboard.scale.com/nucleus/docs/api"
 packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = "^3.6.2"
 requests = "^2.23.0"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
@@ -41,9 +41,6 @@ nest-asyncio = "^1.5.1"
 Sphinx = "^4.2.0"
 pydantic = "^1.8.2"
 isort = "^5.10.1"
-Shapely = "^1.8.0"
-scipy = "^1.7.3"
-numpy = "^1.21.5"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.5"
@@ -61,6 +58,9 @@ sphinx-autobuild = "^2021.3.14"
 furo = "^2021.10.9"
 sphinx-autoapi = "^1.8.4"
 pytest-xdist = "^2.5.0"
+Shapely = { version = "^1.8.0", python = ">=3.7,<3.11" }
+scipy = { version = "^1.7.3", python = ">=3.7,<3.11" }
+numpy = { version = "^1.21.5", python = ">=3.7,<3.11" }
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://dashboard.scale.com/nucleus/docs/api"
 packages = [{include="nucleus"}]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = ">=3.7,<3.11"
 requests = "^2.23.0"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
@@ -41,6 +41,9 @@ nest-asyncio = "^1.5.1"
 Sphinx = "^4.2.0"
 pydantic = "^1.8.2"
 isort = "^5.10.1"
+Shapely = "^1.8.0"
+scipy = "^1.7.3"
+numpy = "^1.21.5"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.5"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+import math
 import os
 import uuid
 from pathlib import Path
@@ -132,6 +133,24 @@ TEST_POLYGON_ANNOTATIONS = [
                 {
                     "x": 50 + i * 10 + j,
                     "y": 60 + i * 10 + j,
+                }
+                for j in range(3)
+            ],
+        },
+        "reference_id": reference_id_from_url(TEST_IMG_URLS[i]),
+        "annotation_id": f"[Pytest] Polygon Annotation Annotation Id{i}",
+    }
+    for i in range(len(TEST_IMG_URLS))
+]
+
+TEST_CONVEX_POLYGON_ANNOTATIONS = [
+    {
+        "label": f"[Pytest] Polygon Annotation ${i}",
+        "geometry": {
+            "vertices": [
+                {
+                    "x": 50 + i * 10 + math.cos(2 * j * math.pi / 3),
+                    "y": 60 + i * 10 + math.sin(2 * j * math.pi / 3),
                 }
                 for j in range(3)
             ],

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -51,7 +51,7 @@ TEST_ANNOTATION_LIST = AnnotationList(
             height=3,
             reference_id="image_1",
             annotation_id="image_1_car_box_1",
-        )
+        ),
     ]
 )
 
@@ -76,9 +76,10 @@ TEST_PREDICTION_LIST = PredictionList(
             reference_id="image_1",
             confidence=0.9,
             annotation_id="image_1_car_box_1",
-        )
+        ),
     ]
 )
+
 
 def assert_metric_eq(actual, expected):
     assert expected.value == pytest.approx(actual.value)

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -1,30 +1,85 @@
 import pytest
 
-from nucleus.annotation import BoxAnnotation, PolygonAnnotation
-from nucleus.metrics.base import Metric, MetricResult
+from nucleus.annotation import BoxAnnotation, PolygonAnnotation, AnnotationList
+from nucleus.prediction import BoxPrediction, PolygonPrediction, PredictionList
 from tests.helpers import TEST_BOX_ANNOTATIONS, TEST_CONVEX_POLYGON_ANNOTATIONS
 
-TEST_BOX_ANNOTATIONS = [
-    BoxAnnotation(**annotation) for annotation in TEST_BOX_ANNOTATIONS
-]
+TEST_BOX_ANNOTATION_LIST = AnnotationList(
+    box_annotations=[
+        BoxAnnotation(**annotation) for annotation in TEST_BOX_ANNOTATIONS
+    ]
+)
+
+TEST_BOX_PREDICTION_LIST = PredictionList(
+    box_predictions=[
+        BoxPrediction(**annotation) for annotation in TEST_BOX_ANNOTATIONS
+    ]
+)
 
 
-TEST_CONVEX_POLYGON_ANNOTATIONS = [
-    PolygonAnnotation.from_json(annotation)
-    for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
-]
+TEST_CONVEX_POLYGON_ANNOTATION_LIST = AnnotationList(
+    polygon_annotations=[
+        PolygonAnnotation.from_json(annotation)
+        for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
+    ]
+)
 
+TEST_CONVEX_POLYGON_PREDICTION_LIST = PredictionList(
+    polygon_predictions=[
+        PolygonPrediction.from_json(annotation)
+        for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
+    ]
+)
+
+
+TEST_ANNOTATION_LIST = AnnotationList(
+    box_annotations=[
+        BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+        ),
+        BoxAnnotation(
+            label="car",
+            x=5,
+            y=5,
+            width=3,
+            height=3,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+        )
+    ]
+)
+
+TEST_PREDICTION_LIST = PredictionList(
+    box_predictions=[
+        BoxPrediction(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            confidence=0.9,
+            annotation_id="image_1_car_box_1",
+        ),
+        BoxPrediction(
+            label="car",
+            x=5,
+            y=5,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            confidence=0.9,
+            annotation_id="image_1_car_box_1",
+        )
+    ]
+)
 
 def assert_metric_eq(actual, expected):
     assert expected.value == pytest.approx(actual.value)
     assert expected.weight == pytest.approx(actual.weight)
-
-
-def perfect_match_test_wrapper(test_data, metric_fn):
-    metric = metric_fn(enforce_label_match=False)
-    result = metric(test_data, test_data)
-    assert_metric_eq(result, MetricResult(1, len(test_data)))
-
-    metric = metric_fn(enforce_label_match=True)
-    result = metric(test_data, test_data)
-    assert_metric_eq(result, MetricResult(1, len(test_data)))

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nucleus.annotation import BoxAnnotation, PolygonAnnotation, AnnotationList
+from nucleus.annotation import AnnotationList, BoxAnnotation, PolygonAnnotation
 from nucleus.prediction import BoxPrediction, PolygonPrediction, PredictionList
 from tests.helpers import TEST_BOX_ANNOTATIONS, TEST_CONVEX_POLYGON_ANNOTATIONS
 

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -1,0 +1,30 @@
+import pytest
+
+from nucleus.annotation import BoxAnnotation, PolygonAnnotation
+from nucleus.metrics.base import Metric, MetricResult
+from tests.helpers import TEST_BOX_ANNOTATIONS, TEST_CONVEX_POLYGON_ANNOTATIONS
+
+TEST_BOX_ANNOTATIONS = [
+    BoxAnnotation(**annotation) for annotation in TEST_BOX_ANNOTATIONS
+]
+
+
+TEST_CONVEX_POLYGON_ANNOTATIONS = [
+    PolygonAnnotation.from_json(annotation)
+    for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
+]
+
+
+def assert_metric_eq(actual, expected):
+    assert expected.value == pytest.approx(actual.value)
+    assert expected.weight == pytest.approx(actual.weight)
+
+
+def perfect_match_test_wrapper(test_data, metric_fn):
+    metric = metric_fn(enforce_label_match=False)
+    result = metric(test_data, test_data)
+    assert_metric_eq(result, MetricResult(1, len(test_data)))
+
+    metric = metric_fn(enforce_label_match=True)
+    result = metric(test_data, test_data)
+    assert_metric_eq(result, MetricResult(1, len(test_data)))

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -1,15 +1,16 @@
-import pytest
 from copy import deepcopy
+
+import pytest
 
 from nucleus.metrics import PolygonIOU, PolygonPrecision, PolygonRecall
 from nucleus.metrics.base import Metric, MetricResult
 from tests.metrics.helpers import (
     TEST_ANNOTATION_LIST,
-    TEST_PREDICTION_LIST,
     TEST_BOX_ANNOTATION_LIST,
     TEST_BOX_PREDICTION_LIST,
     TEST_CONVEX_POLYGON_ANNOTATION_LIST,
     TEST_CONVEX_POLYGON_PREDICTION_LIST,
+    TEST_PREDICTION_LIST,
     assert_metric_eq,
 )
 

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -14,15 +14,32 @@ from tests.metrics.helpers import (
 )
 
 
-@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn", [
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonIOU),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonPrecision),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonRecall),
-])
-def test_perfect_match_polygon_metrics(test_annotations, test_predictions, metric_fn):
+@pytest.mark.parametrize(
+    "test_annotations,test_predictions,metric_fn",
+    [
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonIOU,
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonPrecision,
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonRecall,
+        ),
+    ],
+)
+def test_perfect_match_polygon_metrics(
+    test_annotations, test_predictions, metric_fn
+):
     # Test metrics on where annotations = predictions perfectly
     metric = metric_fn(enforce_label_match=False)
     result = metric(test_annotations, test_predictions)
@@ -33,15 +50,32 @@ def test_perfect_match_polygon_metrics(test_annotations, test_predictions, metri
     assert_metric_eq(result, MetricResult(1, len(test_annotations)))
 
 
-@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn", [
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
-    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonIOU),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonPrecision),
-    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonRecall),
-])
-def test_perfect_unmatched_polygon_metrics(test_annotations, test_predictions, metric_fn):
+@pytest.mark.parametrize(
+    "test_annotations,test_predictions,metric_fn",
+    [
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonIOU,
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonPrecision,
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonRecall,
+        ),
+    ],
+)
+def test_perfect_unmatched_polygon_metrics(
+    test_annotations, test_predictions, metric_fn
+):
     # Test metrics on where annotations and predictions do not have matching reference IDs.
     test_predictions_unmatch = deepcopy(test_predictions)
     for box in test_predictions_unmatch.box_predictions:
@@ -57,12 +91,32 @@ def test_perfect_unmatched_polygon_metrics(test_annotations, test_predictions, m
     assert_metric_eq(result, MetricResult(0, len(test_annotations)))
 
 
-@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn,expected", [
-    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonIOU, MetricResult(0.545, 2)),
-    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonPrecision, MetricResult(0.5, 2)),
-    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonRecall, MetricResult(0.5, 2)),
-])
-def test_simple_2_boxes(test_annotations, test_predictions, metric_fn, expected):
+@pytest.mark.parametrize(
+    "test_annotations,test_predictions,metric_fn,expected",
+    [
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonIOU,
+            MetricResult(0.545, 2),
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonPrecision,
+            MetricResult(0.5, 2),
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonRecall,
+            MetricResult(0.5, 2),
+        ),
+    ],
+)
+def test_simple_2_boxes(
+    test_annotations, test_predictions, metric_fn, expected
+):
     # Test metrics on where annotations = predictions perfectly
     metric = metric_fn()
     result = metric(test_annotations, test_predictions)

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -1,20 +1,69 @@
+import pytest
+from copy import deepcopy
+
 from nucleus.metrics import PolygonIOU, PolygonPrecision, PolygonRecall
+from nucleus.metrics.base import Metric, MetricResult
 from tests.metrics.helpers import (
-    TEST_BOX_ANNOTATIONS,
-    TEST_CONVEX_POLYGON_ANNOTATIONS,
-    perfect_match_test_wrapper,
+    TEST_ANNOTATION_LIST,
+    TEST_PREDICTION_LIST,
+    TEST_BOX_ANNOTATION_LIST,
+    TEST_BOX_PREDICTION_LIST,
+    TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+    TEST_CONVEX_POLYGON_PREDICTION_LIST,
+    assert_metric_eq,
 )
 
 
-def test_perfect_match_box_metrics():
-    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonIOU)
-    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonPrecision)
-    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonRecall)
+@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn", [
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonIOU),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonPrecision),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonRecall),
+])
+def test_perfect_match_polygon_metrics(test_annotations, test_predictions, metric_fn):
+    # Test metrics on where annotations = predictions perfectly
+    metric = metric_fn(enforce_label_match=False)
+    result = metric(test_annotations, test_predictions)
+    assert_metric_eq(result, MetricResult(1, len(test_annotations)))
+
+    metric = metric_fn(enforce_label_match=True)
+    result = metric(test_annotations, test_predictions)
+    assert_metric_eq(result, MetricResult(1, len(test_annotations)))
 
 
-def test_perfect_match_polygon_metrics():
-    perfect_match_test_wrapper(TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonIOU)
-    perfect_match_test_wrapper(
-        TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonPrecision
-    )
-    perfect_match_test_wrapper(TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonRecall)
+@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn", [
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
+    (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonIOU),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonPrecision),
+    (TEST_CONVEX_POLYGON_ANNOTATION_LIST, TEST_CONVEX_POLYGON_PREDICTION_LIST, PolygonRecall),
+])
+def test_perfect_unmatched_polygon_metrics(test_annotations, test_predictions, metric_fn):
+    # Test metrics on where annotations and predictions do not have matching reference IDs.
+    test_predictions_unmatch = deepcopy(test_predictions)
+    for box in test_predictions_unmatch.box_predictions:
+        box.reference_id += "_bad"
+    for polygon in test_predictions_unmatch.polygon_predictions:
+        polygon.reference_id += "_bad"
+    metric = metric_fn(enforce_label_match=False)
+    result = metric(test_annotations, test_predictions_unmatch)
+    assert_metric_eq(result, MetricResult(0, len(test_annotations)))
+
+    metric = metric_fn(enforce_label_match=True)
+    result = metric(test_annotations, test_predictions_unmatch)
+    assert_metric_eq(result, MetricResult(0, len(test_annotations)))
+
+
+@pytest.mark.parametrize("test_annotations,test_predictions,metric_fn,expected", [
+    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonIOU, MetricResult(0.545, 2)),
+    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonPrecision, MetricResult(0.5, 2)),
+    (TEST_ANNOTATION_LIST, TEST_PREDICTION_LIST, PolygonRecall, MetricResult(0.5, 2)),
+])
+def test_simple_2_boxes(test_annotations, test_predictions, metric_fn, expected):
+    # Test metrics on where annotations = predictions perfectly
+    metric = metric_fn()
+    result = metric(test_annotations, test_predictions)
+    assert_metric_eq(result, expected)

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -1,0 +1,20 @@
+from nucleus.metrics import PolygonIOU, PolygonPrecision, PolygonRecall
+from tests.metrics.helpers import (
+    TEST_BOX_ANNOTATIONS,
+    TEST_CONVEX_POLYGON_ANNOTATIONS,
+    perfect_match_test_wrapper,
+)
+
+
+def test_perfect_match_box_metrics():
+    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonIOU)
+    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonPrecision)
+    perfect_match_test_wrapper(TEST_BOX_ANNOTATIONS, PolygonRecall)
+
+
+def test_perfect_match_polygon_metrics():
+    perfect_match_test_wrapper(TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonIOU)
+    perfect_match_test_wrapper(
+        TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonPrecision
+    )
+    perfect_match_test_wrapper(TEST_CONVEX_POLYGON_ANNOTATIONS, PolygonRecall)


### PR DESCRIPTION
Adds IoU, precision, and recall metrics to the Nucleus repository. Creates framework to support more general metrics.

**Note:** adding the `Shapely` package also adds a dependency on the `geos` library, which can be installed in MacOS using `brew install geos`.

Design doc here: https://docs.google.com/document/d/1uOjZQ9wRMdpsOaYN_w6eTqPvQu0Nwtl5wRNj0HkL0EU/edit#heading=h.raendxyxrl42
[ch318548](https://app.shortcut.com/scaleai/story/318548)
[ch303550](https://app.shortcut.com/scaleai/story/303550)