### PR TITLE
add Slice raw export method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-04
+
+### Added
+- `Slice.export_raw_items()` method that fetches accessible (signed) URLs for all items in the Slice.
+
+## [0.4.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.3) - 2022-01-03
+
+### Added
+- Improved error messages for categorization
+
+### Changed
+- Category taxonomies are now updatable
+
 ## [0.4.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.2) - 2021-12-16
 
 ### Added

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -280,6 +280,29 @@ class Slice:
         )
         return api_payload
 
+    def export_raw_items(self) -> List[Dict[str, str]]:
+        """Fetches a list of accessible URLs for each item in the Slice.
+
+        Returns:
+            List where each element is a dict containing a DatasetItem and its
+            accessible (signed) Scale URL.
+            ::
+
+                List[{
+                    "id": str,
+                    "ref_id": str,
+                    "metadata": Dict[str, Union[str, int]],
+                    "original_url": str,
+                    "scale_url": str
+                }]
+        """
+        api_payload = self._client.make_request(
+            payload=None,
+            route=f"slice/{self.id}/exportRawItems",
+            requests_command=requests.get,
+        )
+        return api_payload
+
 
 def check_annotations_are_in_slice(
     annotations: List[Annotation], slice_to_check: Slice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.4.3"
+version = "0.4.4"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -1,7 +1,7 @@
 import copy
-import requests
 
 import pytest
+import requests
 
 from nucleus import BoxAnnotation, Dataset, DatasetItem, NucleusClient, Slice
 from nucleus.constants import (


### PR DESCRIPTION
# Summary
* add `Slice.export_raw_items()`

Related: https://github.com/scaleapi/scaleapi/pull/34209

## Test

I've decided to omit integration tests, since this probably won't be a long-standing solution. If we did want to codify the following manual test, I could maybe cURL or wget each `scale_url` and verify that the content matches byte-for-byte with a locally stored, git-aware copy of the image.

Client (select@scaleapi.com) successfully retrieves accessible URLs for items in slice `slc_c71qg78crvj007g3xtq0` (from dataset `ds_bwkezj6g5c4g05gqp1eg`):
```
In [14]: slc.export_raw_items()
Out[14]:
{'name': 'Bad reflection predictions',
 'slice_id': 'slc_c71qg78crvj007g3xtq0',
 'dataset_id': 'ds_bwkezj6g5c4g05gqp1eg',
 'raw_dataset_items': [{'id': 'di_bwkhrgj1aep005r7yvb0',
   'ref_id': '3b59c8a5-f0b031cc.jpg',
   'metadata': {'scene': 'highway', 'weather': 'clear', 'timeofday': 'night'},
   'original_url': 's3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/3b59c8a5-f0b031cc.jpg',
   'scale_url': 'https://attachments.labeling-data.net/scale-select%2Fnucleus%2F94801889-997b-486b-8a78-da6221773fc0?Expires=1642032000&Key-Pair-Id=APKAIGOZDNNPITVQK2FQ&Signature=gXhhhmLX8stN3aEr~Eo0AqhYWoxM-fkis0~fuq55N3cUZGJ3WIUU0FCcdBP9QMa2suarEsFNqYWt54dkhwsHvQcEJhX1wiLGlm4tOAW-2tdKd-dxFUHG~7ro3m01F3ON~YOBQT3YlPU5SOeZTj027-UPvbd9BEzYhpf70Z888w~B73juvc57Tb2dBONCuG37x8rZad9d7ECWzvDAJHoXLPGVT-ORE~sM6LXMuVLuoJEd2JxbFMOH7huCSY6nlujg0rD8Y~1cQIof4R9l0S2SPixmD4Zbht~ArY76qoUNSJ0AttwN4smlHDKZw5m6WFtWHiaNmXxmELu5DXawT1ilGQ__'},
  {'id': 'di_bwkhrgj1aep005r7yw30',
   'ref_id': 'a758cbed-b0ab28f2.jpg',
   'metadata': {'scene': 'highway',
    'weather': 'clear',
    'timeofday': 'night',
    'review_status': 'rejected'},
   'original_url': 's3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/a758cbed-b0ab28f2.jpg',
   'scale_url': 'https://attachments.labeling-data.net/scale-select%2Fnucleus%2F0f930424-ef35-4168-bee3-60556a2a2556?Expires=1642032000&Key-Pair-Id=APKAIGOZDNNPITVQK2FQ&Signature=Dr4oQ7afcWhh7k4KH8oKLQf1Zt80ao00io9K7Pkvie96I~kLazfpPfNX-iTNflcWGNK6EsZvRMZGSE3KBOPMoCbTruSvnD0llhgvVzpMuXK2X~1NgfhMcuNeNSSxr5iIyPqMwIaPxBRWtKNtlVF~dZAXA5Q0CwRMbeUSWbteadHZLDtXmZCnTMPm4jjq-PocyvjASFrXIC09jiiq32Y8iqx8jTm0Z4EpWGFZmJ07KRKAFY~r7Q3z5qrBvf0EtFJr40Yfpe5wKkYuC-xiIwA2soR8mmVIzH91tYvig2SHcNBv6LryqwWxm4fSc6abpFAlFFUOY~8yckwQODf78JmmyQ__'},
  {'id': 'di_bwkhrgj1aep005r7z040',
   'ref_id': '0582a25c-c66c3fb3.jpg',
   'metadata': {'scene': 'city street',
    'weather': 'clear',
    'timeofday': 'night'},
   'original_url': 's3://scaleapi-attachments/BDD/BDD/bdd100k/images/100k/train/0582a25c-c66c3fb3.jpg',
   'scale_url': 'https://attachments.labeling-data.net/scale-select%2Fnucleus%2Fa87084f7-8306-4564-9643-d6244ba6353f?Expires=1642032000&Key-Pair-Id=APKAIGOZDNNPITVQK2FQ&Signature=Xt7QXAR8X2g7z79n7IE02OAgkqAOO8faBR5VVb7ukabF-jiy1apJNtVCtpzpmeP4rZcrG3GlG99b3qugilF3sy7zFpm8Y4M1r84nW~IRgBzODxgUFSgB6Ah1BeAaOCvJ3BC9WJ0my5VShsAbNWFwW~NR5H77J5v3OozqLTS~-TP0X2lSQfdPE~jDQpMBVcLlPRqPP9YncFELeZYSWtLt~fZaTS1I7KwAqMl306UeHFubcEC5hkgFSgG3QagSBsP~Pl8a~H9K8peINacf~RFKJ6SOF8iRfhwBjFHyIzKt92giIM8895awAPJrtDf5-Hen8yhWgk4c5SdMXW3krhTD~A__'}]}
```

Export fails when userId is removed from feature flag:
```
In [17]: slc.export_raw_items()
---------------------------------------------------------------------------
NucleusAPIError                           Traceback (most recent call last)
<ipython-input-17-ebe001c786e1> in <module>
----> 1 slc.export_raw_items()

~/nucleus-python-client/nucleus/slice.py in export_raw_items(self)
    300             payload=None,
    301             route=f"slice/{self.id}/exportRawItems",
--> 302             requests_command=requests.get,
    303         )
    304         return api_payload

~/nucleus-python-client/nucleus/__init__.py in make_request(self, payload, route, requests_command)
    928         if payload is None:
    929             payload = {}
--> 930         return self._connection.make_request(payload, route, requests_command)  # type: ignore
    931
    932     def handle_bad_response(

~/nucleus-python-client/nucleus/connection.py in make_request(self, payload, route, requests_command)
     72
     73         if not response.ok:
---> 74             self.handle_bad_response(endpoint, requests_command, response)
     75
     76         return response.json()

~/nucleus-python-client/nucleus/connection.py in handle_bad_response(self, endpoint, requests_command, requests_response, aiohttp_response)
     84     ):
     85         raise NucleusAPIError(
---> 86             endpoint, requests_command, requests_response, aiohttp_response
     87         )

NucleusAPIError: Your client is on version 0.4.3. If you have not recently done so, please make sure you have updated to the latest version of the client by running pip install --upgrade scale-nucleus
Tried to get http://localhost:3000/v1/nucleus/slice/slc_c71qg78crvj007g3xtq0/exportRawItems, but received 401: Unauthorized.
The detailed error is:
{"status_code":401,"error":"Raw data export is currently in private beta. If you're interested in trying it out please contact us at support@scale.com."}
```