### PR TITLE
add Dataset.scenes property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-07
+
+### Added
+- `Dataset.scenes_list` property that fetches the Scale-generated ID, reference ID, type, and metadata of all scenes in the Dataset.
+
 ## [0.4.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-07
 
 ### Added
-- `Dataset.scenes_list` property that fetches the Scale-generated ID, reference ID, type, and metadata of all scenes in the Dataset.
+- `Dataset.scenes` property that fetches the Scale-generated ID, reference ID, type, and metadata of all scenes in the Dataset.
 
 ## [0.4.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.4.4) - 2021-01-04
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -140,7 +140,7 @@ class Dataset:
         return response
 
     @property
-    def model_runs(self) -> Dict[Any, Any]:
+    def model_runs(self) -> List[str]:
         """List of all model runs associated with the Dataset."""
         # TODO: model_runs -> models
         response = self._client.make_request(
@@ -149,7 +149,7 @@ class Dataset:
         return response
 
     @property
-    def slices(self) -> Dict[Any, Any]:
+    def slices(self) -> List[str]:
         """List of all Slice IDs created from the Dataset."""
         response = self._client.make_request(
             {}, f"dataset/{self.id}/slices", requests.get

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -185,6 +185,15 @@ class Dataset:
             raise DatasetItemRetrievalError(message=error)
         return constructed_dataset_items
 
+    @property
+    def scenes_list(self) -> List[Dict[str, Any]]:
+        """List of ID, reference ID, type, and metadata for all scenes in the Dataset."""
+        response = self._client.make_request(
+            {}, f"dataset/{self.id}/scenes_list", requests.get
+        )
+
+        return response.get("scenes", None)
+
     @sanitize_string_args
     def autotag_items(self, autotag_name, for_scores_greater_than=0):
         """Fetches the autotag's items above the score threshold, sorted by descending score.

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -186,7 +186,7 @@ class Dataset:
         return constructed_dataset_items
 
     @property
-    def scenes_list(self) -> List[Dict[str, Any]]:
+    def scenes(self) -> List[Dict[str, Any]]:
         """List of ID, reference ID, type, and metadata for all scenes in the Dataset."""
         response = self._client.make_request(
             {}, f"dataset/{self.id}/scenes_list", requests.get

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.4.4"
+version = "0.4.5"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -379,7 +379,6 @@ def test_scene_upload_and_update(dataset_scene):
     scenes = [
         LidarScene.from_json(scene_json) for scene_json in payload[SCENES_KEY]
     ]
-    reference_ids = [s.reference_id for s in scenes]
     update = payload[UPDATE_KEY]
 
     job = dataset_scene.append(scenes, update=update, asynchronous=True)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -273,6 +273,9 @@ def test_scene_upload_sync(dataset_scene):
 
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
+    # TODO(drake) once this test is working again:
+    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # other validations such as correct reference_id, metadata propagation
 
 
 @pytest.mark.skip("Deactivated sync upload for scenes")
@@ -288,6 +291,9 @@ def test_scene_and_cuboid_upload_sync(dataset_scene):
 
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
+    # TODO(drake) once this test is working again:
+    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # other validations such as correct reference_id, metadata propagation
 
     lidar_item_ref = payload[SCENES_KEY][0][FRAMES_KEY][0]["lidar"][
         REFERENCE_ID_KEY
@@ -340,6 +346,10 @@ def test_scene_upload_async(dataset_scene):
         "completed_steps": 1,
         "total_steps": 1,
     }
+
+    # TODO(drake) once this test is working again:
+    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # other validations such as correct reference_id, metadata propagation
 
 
 @pytest.mark.skip(reason="Temporarily skipped because failing 12/28/21")

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -273,9 +273,16 @@ def test_scene_upload_sync(dataset_scene):
 
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
-    # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes) == len(scenes)
-    # other validations such as correct reference_id, metadata propagation
+
+    uploaded_scenes = dataset_scene.scenes
+    assert len(uploaded_scenes) == len(scenes)
+    assert all(
+        u["reference_id"] == o.reference_id
+        for u, o in zip(uploaded_scenes, scenes)
+    )
+    assert all(
+        u["metadata"] == o.metadata for u, o in zip(uploaded_scenes, scenes)
+    )
 
 
 @pytest.mark.skip("Deactivated sync upload for scenes")
@@ -291,9 +298,16 @@ def test_scene_and_cuboid_upload_sync(dataset_scene):
 
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
-    # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes) == len(scenes)
-    # other validations such as correct reference_id, metadata propagation
+
+    uploaded_scenes = dataset_scene.scenes
+    assert len(uploaded_scenes) == len(scenes)
+    assert all(
+        u["reference_id"] == o.reference_id
+        for u, o in zip(uploaded_scenes, scenes)
+    )
+    assert all(
+        u["metadata"] == o.metadata for u, o in zip(uploaded_scenes, scenes)
+    )
 
     lidar_item_ref = payload[SCENES_KEY][0][FRAMES_KEY][0]["lidar"][
         REFERENCE_ID_KEY
@@ -347,9 +361,15 @@ def test_scene_upload_async(dataset_scene):
         "total_steps": 1,
     }
 
-    # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes) == len(scenes)
-    # other validations such as correct reference_id, metadata propagation
+    uploaded_scenes = dataset_scene.scenes
+    assert len(uploaded_scenes) == len(scenes)
+    assert all(
+        u["reference_id"] == o.reference_id
+        for u, o in zip(uploaded_scenes, scenes)
+    )
+    assert all(
+        u["metadata"] == o.metadata for u, o in zip(uploaded_scenes, scenes)
+    )
 
 
 @pytest.mark.skip(reason="Temporarily skipped because failing 12/28/21")
@@ -384,10 +404,15 @@ def test_scene_upload_and_update(dataset_scene):
         "total_steps": 1,
     }
 
-    fetched_scenes = [
-        dataset_scene.get_scene(ref_id) for ref_id in reference_ids
-    ]
-    assert len(fetched_scenes) == len(scenes)
+    uploaded_scenes = dataset_scene.scenes
+    assert len(uploaded_scenes) == len(scenes)
+    assert all(
+        u["reference_id"] == o.reference_id
+        for u, o in zip(uploaded_scenes, scenes)
+    )
+    assert all(
+        u["metadata"] == o.metadata for u, o in zip(uploaded_scenes, scenes)
+    )
 
     job2 = dataset_scene.append(scenes, update=True, asynchronous=True)
     job2.sleep_until_complete()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -274,7 +274,7 @@ def test_scene_upload_sync(dataset_scene):
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
     # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # assert len(dataset_scenes.scenes) == len(scenes)
     # other validations such as correct reference_id, metadata propagation
 
 
@@ -292,7 +292,7 @@ def test_scene_and_cuboid_upload_sync(dataset_scene):
     assert response["dataset_id"] == dataset_scene.id
     assert response["new_scenes"] == len(scenes)
     # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # assert len(dataset_scenes.scenes) == len(scenes)
     # other validations such as correct reference_id, metadata propagation
 
     lidar_item_ref = payload[SCENES_KEY][0][FRAMES_KEY][0]["lidar"][
@@ -348,7 +348,7 @@ def test_scene_upload_async(dataset_scene):
     }
 
     # TODO(drake) once this test is working again:
-    # assert len(dataset_scenes.scenes_list) == len(scenes)
+    # assert len(dataset_scenes.scenes) == len(scenes)
     # other validations such as correct reference_id, metadata propagation
 
 


### PR DESCRIPTION
Useful for fetching all scene `reference_id`s associated with a Dataset.

## Test Plan
Verified with local endpoint that the new property fetches the intended payload:
```
In [3]: client.get_dataset('ds_c6k6bpyk65mg0w31450g').scenes[-3:]
Out[3]:
[{'id': 'scn_c6k6kzz00t400wbnafgg',
  'reference_id': '5db9be454fbbda0f4fb1cc4a',
  'type': 'lidar',
  'metadata': {'scene': 1}},
 {'id': 'scn_c6k6kzz00t400wbna6r0',
  'reference_id': '5db9be454fbbda0f4fb1cc49',
  'type': 'lidar',
  'metadata': {'scene': 21}},
 {'id': 'scn_c6k6kzz00t400wbn9xzg',
  'reference_id': '5db9be454fbbda0f4fb1cc48',
  'type': 'lidar',
  'metadata': {'scene': 23}}]
```