### PR TITLE
Reinstate skipped tests in test_scene

### DIFF
--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -310,7 +310,6 @@ def test_scene_and_cuboid_upload_sync(dataset_scene):
     )
 
 
-@pytest.mark.skip(reason="Temporarily skipped because failing 12/28/21")
 @pytest.mark.integration
 def test_scene_upload_async(dataset_scene):
     payload = TEST_LIDAR_SCENES
@@ -342,7 +341,6 @@ def test_scene_upload_async(dataset_scene):
     }
 
 
-@pytest.mark.skip(reason="Temporarily skipped because failing 12/28/21")
 @pytest.mark.integration
 def test_scene_upload_and_update(dataset_scene):
     payload = TEST_LIDAR_SCENES


### PR DESCRIPTION
The skipped tests were failing due to a permissions issue on the server. These issues were fixed and these tests should now be re-run.