### PR TITLE
Make dependencies work for python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ orbs:
 jobs:
   build_test:
     docker:
-      - image: python:3.7-buster
+      # Important: Don't change this otherwise we will stop testing the earliest
+      # python version we have to support.
+      - image: python:3.6-buster
     resource_class: small
     parallelism: 6
     steps:
@@ -23,7 +25,7 @@ jobs:
       - run:
           name: Black Formatting Check # Only validation, without re-formatting
           command: |
-            poetry run black --check -t py37 .
+            poetry run black --check -t py36 .
       - run:
           name: Flake8 Lint Check # Uses setup.cfg for configuration
           command: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ nest-asyncio = "^1.5.1"
 Sphinx = "^4.2.0"
 pydantic = "^1.8.2"
 isort = "^5.10.1"
+numpy = "^1.19.5"
+scipy = "^1.5.4"
+Shapely = "^1.8.0"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.5"
@@ -58,9 +61,7 @@ sphinx-autobuild = "^2021.3.14"
 furo = "^2021.10.9"
 sphinx-autoapi = "^1.8.4"
 pytest-xdist = "^2.5.0"
-Shapely = { version = "^1.8.0", python = ">=3.7,<3.11" }
-scipy = { version = "^1.7.3", python = ">=3.7,<3.11" }
-numpy = { version = "^1.21.5", python = ">=3.7,<3.11" }
+
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
* Keep testing on python 3.6
* Move dependencies out of dev 
* Change the versions of dependencies we require so that they can be installed on python 3.6