### PR TITLE
Add AP and MAP to polygon metrics

### DIFF
--- a/nucleus/metrics/__init__.py
+++ b/nucleus/metrics/__init__.py
@@ -1,6 +1,8 @@
 from .base import Metric, MetricResult
 from .polygon_metrics import (
+    PolygonAveragePrecision,
     PolygonIOU,
+    PolygonMAP,
     PolygonMetric,
     PolygonPrecision,
     PolygonRecall,

--- a/nucleus/metrics/filters.py
+++ b/nucleus/metrics/filters.py
@@ -3,14 +3,14 @@ from typing import List
 from nucleus.prediction import PredictionList
 
 from .polygon_utils import (
-    BoxOrPolygonAnnotation,
+    BoxOrPolygonAnnoOrPred,
     polygon_annotation_to_geometry,
 )
 
 
 def polygon_area_filter(
-    polygons: List[BoxOrPolygonAnnotation], min_area: float, max_area: float
-) -> List[BoxOrPolygonAnnotation]:
+    polygons: List[BoxOrPolygonAnnoOrPred], min_area: float, max_area: float
+) -> List[BoxOrPolygonAnnoOrPred]:
     filter_fn = (
         lambda polygon: min_area
         <= polygon_annotation_to_geometry(polygon).signed_area
@@ -32,3 +32,9 @@ def confidence_filter(
             filter(filter_fn, predictions.__dict__[attr])
         )
     return predictions_copy
+
+
+def polygon_label_filter(
+    polygons: List[BoxOrPolygonAnnoOrPred], label: str
+) -> List[BoxOrPolygonAnnoOrPred]:
+    return list(filter(lambda polygon: polygon.label == label, polygons))

--- a/nucleus/metrics/metric_utils.py
+++ b/nucleus/metrics/metric_utils.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+
+def compute_average_precision(recall, precision):
+    """Compute the average precision, given the recall and precision curves.
+    Code originally from https://github.com/rbgirshick/py-faster-rcnn.
+    # Arguments
+        recall:    The recall curve (list).
+        precision: The precision curve (list).
+    # Returns
+        The average precision as computed in py-faster-rcnn.
+    """
+    # correct AP calculation
+    # first append sentinel values at the end
+    mrec = np.concatenate(([0.0], recall, [1.0]))
+    mpre = np.concatenate(([0.0], precision, [0.0]))
+
+    # compute the precision envelope
+    for i in range(mpre.size - 1, 0, -1):
+        mpre[i - 1] = np.maximum(mpre[i - 1], mpre[i])
+
+    # to calculate area under PR curve, look for points
+    # where X axis (recall) changes value
+    i = np.where(mrec[1:] != mrec[:-1])[0]
+
+    # and sum (\Delta recall) * prec
+    ap = np.sum((mrec[i + 1] - mrec[i]) * mpre[i + 1])
+    return ap

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -2,14 +2,19 @@ import sys
 from abc import abstractmethod
 from typing import List, Union
 
+import numpy as np
+
 from nucleus.annotation import AnnotationList, BoxAnnotation, PolygonAnnotation
 from nucleus.prediction import BoxPrediction, PolygonPrediction, PredictionList
 
 from .base import Metric, MetricResult
-from .filters import confidence_filter
+from .filters import confidence_filter, polygon_label_filter
+from .metric_utils import compute_average_precision
 from .polygon_utils import (
     BoxOrPolygonAnnotation,
     BoxOrPolygonPrediction,
+    get_true_false_positives_confidences,
+    group_boxes_or_polygons_by_label,
     iou_assignments,
     label_match_wrapper,
     num_true_positives,
@@ -30,7 +35,10 @@ class PolygonMetric(Metric):
     with logic to define a metric between box/polygon annotations and predictions.
     ::
 
-        from nucleus import BoxAnnotation
+        from typing import List
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
         from nucleus.metrics import MetricResult, PolygonMetric
         from nucleus.metrics.polygon_utils import BoxOrPolygonAnnotation, BoxOrPolygonPrediction
 
@@ -44,7 +52,7 @@ class PolygonMetric(Metric):
                 weight = len(annotations)
                 return MetricResult(value, weight)
 
-        box = BoxAnnotation(
+        box_anno = BoxAnnotation(
             label="car",
             x=0,
             y=0,
@@ -55,8 +63,19 @@ class PolygonMetric(Metric):
             metadata={"vehicle_color": "red"}
         )
 
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
         metric = MyPolygonMetric()
-        metric([box], [box])
+        metric(annotations, predictions)
     """
 
     def __init__(
@@ -107,7 +126,39 @@ class PolygonMetric(Metric):
 
 
 class PolygonIOU(PolygonMetric):
-    """Calculates the average IOU between box or polygon annotations and predictions."""
+    """Calculates the average IOU between box or polygon annotations and predictions.
+    ::
+
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import PolygonIOU
+
+        box_anno = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
+        metric = PolygonIOU()
+        metric(annotations, predictions)
+    """
 
     # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
@@ -143,7 +194,39 @@ class PolygonIOU(PolygonMetric):
 
 
 class PolygonPrecision(PolygonMetric):
-    """Calculates the precision between box or polygon annotations and predictions."""
+    """Calculates the precision between box or polygon annotations and predictions.
+    ::
+
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import PolygonIOU
+
+        box_anno = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
+        metric = PolygonPrecision()
+        metric(annotations, predictions)
+    """
 
     # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
@@ -180,7 +263,39 @@ class PolygonPrecision(PolygonMetric):
 
 
 class PolygonRecall(PolygonMetric):
-    """Calculates the recall between box or polygon annotations and predictions."""
+    """Calculates the recall between box or polygon annotations and predictions.
+    ::
+
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import PolygonIOU
+
+        box_anno = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
+        metric = PolygonRecall()
+        metric(annotations, predictions)
+    """
 
     # TODO: Remove defaults once these are surfaced more cleanly to users.
     def __init__(
@@ -214,3 +329,149 @@ class PolygonRecall(PolygonMetric):
         return MetricResult(
             true_positives / max(weight, sys.float_info.epsilon), weight
         )
+
+
+class PolygonAveragePrecision(PolygonMetric):
+    """Calculates the mean average precision between box or polygon annotations and predictions.
+    ::
+
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import PolygonIOU
+
+        box_anno = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
+        metric = PolygonAveragePrecision(label="car")
+        metric(annotations, predictions)
+    """
+
+    # TODO: Remove defaults once these are surfaced more cleanly to users.
+    def __init__(
+        self,
+        label,
+        iou_threshold: float = 0.5,
+    ):
+        """Initializes PolygonRecall object.
+
+        Args:
+            iou_threshold: IOU threshold to consider detection as valid. Must be in [0, 1]. Default 0.5
+        """
+        assert (
+            0 <= iou_threshold <= 1
+        ), "IoU threshold must be between 0 and 1."
+        self.iou_threshold = iou_threshold
+        self.label = label
+        super().__init__(enforce_label_match=False, confidence_threshold=0)
+
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        annotations_filtered = polygon_label_filter(annotations, self.label)
+        predictions_filtered = polygon_label_filter(predictions, self.label)
+        (
+            true_false_positives,
+            confidences,
+        ) = get_true_false_positives_confidences(
+            annotations_filtered, predictions_filtered, self.iou_threshold
+        )
+        idxes = np.argsort(-confidences)
+        true_false_positives_sorted = true_false_positives[idxes]
+        cumulative_true_positives = np.cumsum(true_false_positives_sorted)
+        total_predictions = np.arange(1, len(true_false_positives) + 1)
+        precisions = cumulative_true_positives / total_predictions
+        recalls = cumulative_true_positives / len(annotations)
+        average_precision = compute_average_precision(precisions, recalls)
+        weight = 1
+        return MetricResult(average_precision, weight)
+
+
+class PolygonMAP(PolygonMetric):
+    """Calculates the mean average precision between box or polygon annotations and predictions.
+    ::
+
+        from nucleus import BoxAnnotation, Point, PolygonPrediction
+        from nucleus.annotation import AnnotationList
+        from nucleus.prediction import PredictionList
+        from nucleus.metrics import PolygonIOU
+
+        box_anno = BoxAnnotation(
+            label="car",
+            x=0,
+            y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            annotation_id="image_1_car_box_1",
+            metadata={"vehicle_color": "red"}
+        )
+
+        polygon_pred = PolygonPrediction(
+            label="bus",
+            vertices=[Point(100, 100), Point(150, 200), Point(200, 100)],
+            reference_id="image_2",
+            annotation_id="image_2_bus_polygon_1",
+            confidence=0.8,
+            metadata={"vehicle_color": "yellow"}
+        )
+
+        annotations = AnnotationList(box_annotations=[box_anno])
+        predictions = PredictionList(polygon_predictions=[polygon_pred])
+        metric = PolygonMAP()
+        metric(annotations, predictions)
+    """
+
+    # TODO: Remove defaults once these are surfaced more cleanly to users.
+    def __init__(
+        self,
+        iou_threshold: float = 0.5,
+    ):
+        """Initializes PolygonRecall object.
+
+        Args:
+            iou_threshold: IOU threshold to consider detection as valid. Must be in [0, 1]. Default 0.5
+        """
+        assert (
+            0 <= iou_threshold <= 1
+        ), "IoU threshold must be between 0 and 1."
+        self.iou_threshold = iou_threshold
+        super().__init__(enforce_label_match=False, confidence_threshold=0)
+
+    def eval(
+        self,
+        annotations: List[BoxOrPolygonAnnotation],
+        predictions: List[BoxOrPolygonPrediction],
+    ) -> MetricResult:
+        grouped_inputs = group_boxes_or_polygons_by_label(
+            annotations, predictions
+        )
+        results: List[MetricResult] = []
+        for label, group in grouped_inputs.items():
+            annotations_group, predictions_group = group
+            metric = PolygonAveragePrecision(label)
+            result = metric.eval(annotations_group, predictions_group)
+            results.append(result)
+        average_result = MetricResult.aggregate(results)
+        return average_result

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -332,7 +332,7 @@ class PolygonRecall(PolygonMetric):
 
 
 class PolygonAveragePrecision(PolygonMetric):
-    """Calculates the mean average precision between box or polygon annotations and predictions.
+    """Calculates the average precision between box or polygon annotations and predictions.
     ::
 
         from nucleus import BoxAnnotation, Point, PolygonPrediction

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -200,7 +200,7 @@ class PolygonPrecision(PolygonMetric):
         from nucleus import BoxAnnotation, Point, PolygonPrediction
         from nucleus.annotation import AnnotationList
         from nucleus.prediction import PredictionList
-        from nucleus.metrics import PolygonIOU
+        from nucleus.metrics import PolygonPrecision
 
         box_anno = BoxAnnotation(
             label="car",
@@ -269,7 +269,7 @@ class PolygonRecall(PolygonMetric):
         from nucleus import BoxAnnotation, Point, PolygonPrediction
         from nucleus.annotation import AnnotationList
         from nucleus.prediction import PredictionList
-        from nucleus.metrics import PolygonIOU
+        from nucleus.metrics import PolygonRecall
 
         box_anno = BoxAnnotation(
             label="car",
@@ -338,7 +338,7 @@ class PolygonAveragePrecision(PolygonMetric):
         from nucleus import BoxAnnotation, Point, PolygonPrediction
         from nucleus.annotation import AnnotationList
         from nucleus.prediction import PredictionList
-        from nucleus.metrics import PolygonIOU
+        from nucleus.metrics import PolygonAveragePrecision
 
         box_anno = BoxAnnotation(
             label="car",
@@ -415,7 +415,7 @@ class PolygonMAP(PolygonMetric):
         from nucleus import BoxAnnotation, Point, PolygonPrediction
         from nucleus.annotation import AnnotationList
         from nucleus.prediction import PredictionList
-        from nucleus.metrics import PolygonIOU
+        from nucleus.metrics import PolygonMAP
 
         box_anno = BoxAnnotation(
             label="car",

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -18,6 +18,13 @@ BoxOrPolygonPrediction = TypeVar(
 BoxOrPolygonAnnotation = TypeVar(
     "BoxOrPolygonAnnotation", BoxAnnotation, PolygonAnnotation
 )
+BoxOrPolygonAnnoOrPred = TypeVar(
+    "BoxOrPolygonAnnoOrPred",
+    BoxAnnotation,
+    PolygonAnnotation,
+    BoxPrediction,
+    PolygonPrediction,
+)
 
 
 def polygon_annotation_to_geometry(
@@ -66,7 +73,13 @@ def _iou_assignments_for_same_reference_id(
     annotations: List[BoxOrPolygonAnnotation],
     predictions: List[BoxOrPolygonPrediction],
     iou_threshold: float,
-) -> np.ndarray:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    # Matches annotations and precitions of the same reference ID.
+    # Returns a tuple of the list of all IoU values of valid assignments, a
+    # list of the indices of predictions matched to annotations (-1 if
+    # unmatched), and a list of all indices of annotations matched to
+    # predictions.
+
     # Check that all annotations and predictions have same reference ID.
     reference_ids = set(annotation.reference_id for annotation in annotations)
     reference_ids |= set(prediction.reference_id for prediction in predictions)
@@ -90,8 +103,17 @@ def _iou_assignments_for_same_reference_id(
     # values below the threshold.
     matched_0, matched_1 = linear_sum_assignment(-iou_matrix)
     iou_assigns = iou_matrix[matched_0, matched_1]
-    iou_assigns = iou_assigns[iou_assigns >= iou_threshold]
-    return iou_assigns
+    valid_idxes = iou_assigns >= iou_threshold
+    iou_assigns = iou_assigns[valid_idxes]
+
+    matched_0 = matched_0[valid_idxes]
+    matched_1 = matched_1[valid_idxes]
+    anno_to_pred = -np.ones(len(annotations))
+    pred_to_anno = -np.ones(len(predictions))
+    anno_to_pred[matched_1] = matched_0
+    pred_to_anno[matched_0] = matched_1
+
+    return iou_assigns, anno_to_pred, pred_to_anno
 
 
 def group_boxes_or_polygons_by_reference_id(
@@ -173,11 +195,47 @@ def iou_assignments(
     )
     iou_assigns = []
     for grouped_annotations, grouped_predictions in grouped_inputs.values():
-        result_per_reference_id = _iou_assignments_for_same_reference_id(
+        result_per_reference_id, _, _ = _iou_assignments_for_same_reference_id(
             grouped_annotations, grouped_predictions, iou_threshold
         )
         iou_assigns.append(result_per_reference_id)
     return np.concatenate(iou_assigns)
+
+
+def get_true_false_positives_confidences(
+    annotations: List[BoxOrPolygonAnnotation],
+    predictions: List[BoxOrPolygonPrediction],
+    iou_threshold: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Matches annotations and predictions based on linear sum cost and returns the
+    intersection-over-union values of the matched annotation-prediction pairs, subject
+    to the specified IoU threshold. Note that annotations and predictions from
+    different reference_ids will not be matched with one another.
+    See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linear_sum_assignment.html
+
+    Args:
+        annotations: list of box or polygon annotations
+        predictions: list of box or polygon predictions
+        iou_threshold: the intersection-over-union threshold for an
+            annotation-prediction pair to be considered a match.
+
+    Returns:
+        1D numpy array that contains the 1 if true positive and 0 if false positive
+            for each prediction.
+        1D numpy array of confidence values.
+    """
+    grouped_inputs = group_boxes_or_polygons_by_reference_id(
+        annotations, predictions
+    )
+    true_false_positives = []
+    confidences = []
+    for grouped_annotations, grouped_predictions in grouped_inputs.values():
+        _, _, pred_to_anno = _iou_assignments_for_same_reference_id(
+            grouped_annotations, grouped_predictions, iou_threshold
+        )
+        true_false_positives.append(pred_to_anno > -1)
+        confidences.extend([pred.confidence for pred in grouped_predictions])
+    return np.concatenate(true_false_positives), np.array(confidences)
 
 
 def num_true_positives(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.5.2"
+version = "0.5.3"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -12,7 +12,8 @@ TEST_BOX_ANNOTATION_LIST = AnnotationList(
 
 TEST_BOX_PREDICTION_LIST = PredictionList(
     box_predictions=[
-        BoxPrediction(**annotation) for annotation in TEST_BOX_ANNOTATIONS
+        BoxPrediction(confidence=0.5, **annotation)
+        for annotation in TEST_BOX_ANNOTATIONS
     ]
 )
 
@@ -26,7 +27,7 @@ TEST_CONVEX_POLYGON_ANNOTATION_LIST = AnnotationList(
 
 TEST_CONVEX_POLYGON_PREDICTION_LIST = PredictionList(
     polygon_predictions=[
-        PolygonPrediction.from_json(annotation)
+        PolygonPrediction.from_json(annotation | {"confidence": 0.5})
         for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
     ]
 )
@@ -61,6 +62,16 @@ TEST_PREDICTION_LIST = PredictionList(
             label="car",
             x=0,
             y=0,
+            width=10,
+            height=10,
+            reference_id="image_1",
+            confidence=0.6,
+            annotation_id="image_1_car_box_1",
+        ),
+        BoxPrediction(
+            label="car",
+            x=5,
+            y=5,
             width=10,
             height=10,
             reference_id="image_1",

--- a/tests/metrics/helpers.py
+++ b/tests/metrics/helpers.py
@@ -27,7 +27,7 @@ TEST_CONVEX_POLYGON_ANNOTATION_LIST = AnnotationList(
 
 TEST_CONVEX_POLYGON_PREDICTION_LIST = PredictionList(
     polygon_predictions=[
-        PolygonPrediction.from_json(annotation | {"confidence": 0.5})
+        PolygonPrediction.from_json(dict(**annotation, confidence=0.5))
         for annotation in TEST_CONVEX_POLYGON_ANNOTATIONS
     ]
 )

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -2,8 +2,14 @@ from copy import deepcopy
 
 import pytest
 
-from nucleus.metrics import PolygonIOU, PolygonPrecision, PolygonRecall
-from nucleus.metrics.base import Metric, MetricResult
+from nucleus.metrics import (
+    PolygonAveragePrecision,
+    PolygonIOU,
+    PolygonMAP,
+    PolygonPrecision,
+    PolygonRecall,
+)
+from nucleus.metrics.base import MetricResult
 from tests.metrics.helpers import (
     TEST_ANNOTATION_LIST,
     TEST_BOX_ANNOTATION_LIST,
@@ -16,66 +22,184 @@ from tests.metrics.helpers import (
 
 
 @pytest.mark.parametrize(
-    "test_annotations,test_predictions,metric_fn",
+    "test_annotations,test_predictions,metric_fn,kwargs",
     [
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": False},
+        ),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonMAP, {}),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonIOU,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": False},
         ),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonPrecision,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": False},
         ),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonRecall,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonMAP,
+            {},
         ),
     ],
 )
 def test_perfect_match_polygon_metrics(
-    test_annotations, test_predictions, metric_fn
+    test_annotations, test_predictions, metric_fn, kwargs
 ):
     # Test metrics on where annotations = predictions perfectly
-    metric = metric_fn(enforce_label_match=False)
-    result = metric(test_annotations, test_predictions)
-    assert_metric_eq(result, MetricResult(1, len(test_annotations)))
-
-    metric = metric_fn(enforce_label_match=True)
+    metric = metric_fn(**kwargs)
     result = metric(test_annotations, test_predictions)
     assert_metric_eq(result, MetricResult(1, len(test_annotations)))
 
 
 @pytest.mark.parametrize(
-    "test_annotations,test_predictions,metric_fn",
+    "test_annotations,test_predictions,metric_fn,kwargs",
     [
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonIOU),
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonPrecision),
-        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonRecall),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_BOX_ANNOTATION_LIST,
+            TEST_BOX_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": False},
+        ),
+        (TEST_BOX_ANNOTATION_LIST, TEST_BOX_PREDICTION_LIST, PolygonMAP, {}),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonIOU,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonIOU,
+            {"enforce_label_match": False},
         ),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonPrecision,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonPrecision,
+            {"enforce_label_match": False},
         ),
         (
             TEST_CONVEX_POLYGON_ANNOTATION_LIST,
             TEST_CONVEX_POLYGON_PREDICTION_LIST,
             PolygonRecall,
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonRecall,
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_CONVEX_POLYGON_ANNOTATION_LIST,
+            TEST_CONVEX_POLYGON_PREDICTION_LIST,
+            PolygonMAP,
+            {},
         ),
     ],
 )
 def test_perfect_unmatched_polygon_metrics(
-    test_annotations, test_predictions, metric_fn
+    test_annotations, test_predictions, metric_fn, kwargs
 ):
     # Test metrics on where annotations and predictions do not have matching reference IDs.
     test_predictions_unmatch = deepcopy(test_predictions)
@@ -83,42 +207,76 @@ def test_perfect_unmatched_polygon_metrics(
         box.reference_id += "_bad"
     for polygon in test_predictions_unmatch.polygon_predictions:
         polygon.reference_id += "_bad"
-    metric = metric_fn(enforce_label_match=False)
-    result = metric(test_annotations, test_predictions_unmatch)
-    assert_metric_eq(result, MetricResult(0, len(test_annotations)))
-
-    metric = metric_fn(enforce_label_match=True)
+    metric = metric_fn(**kwargs)
     result = metric(test_annotations, test_predictions_unmatch)
     assert_metric_eq(result, MetricResult(0, len(test_annotations)))
 
 
 @pytest.mark.parametrize(
-    "test_annotations,test_predictions,metric_fn,expected",
+    "test_annotations,test_predictions,metric_fn,expected,kwargs",
     [
         (
             TEST_ANNOTATION_LIST,
             TEST_PREDICTION_LIST,
             PolygonIOU,
-            MetricResult(0.545, 2),
+            MetricResult(109.0 / 300, 3),
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonIOU,
+            MetricResult(109.0 / 300, 3),
+            {"enforce_label_match": False},
         ),
         (
             TEST_ANNOTATION_LIST,
             TEST_PREDICTION_LIST,
             PolygonPrecision,
-            MetricResult(0.5, 2),
+            MetricResult(1.0 / 3, 3),
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonPrecision,
+            MetricResult(1.0 / 3, 3),
+            {"enforce_label_match": False},
         ),
         (
             TEST_ANNOTATION_LIST,
             TEST_PREDICTION_LIST,
             PolygonRecall,
             MetricResult(0.5, 2),
+            {"enforce_label_match": True},
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonRecall,
+            MetricResult(0.5, 2),
+            {"enforce_label_match": False},
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonAveragePrecision,
+            MetricResult(1.0 / 6, 1),
+            {"label": "car"},
+        ),
+        (
+            TEST_ANNOTATION_LIST,
+            TEST_PREDICTION_LIST,
+            PolygonMAP,
+            MetricResult(1.0 / 6, 1),
+            {},
         ),
     ],
 )
 def test_simple_2_boxes(
-    test_annotations, test_predictions, metric_fn, expected
+    test_annotations, test_predictions, metric_fn, expected, kwargs
 ):
     # Test metrics on where annotations = predictions perfectly
-    metric = metric_fn()
+    metric = metric_fn(**kwargs)
     result = metric(test_annotations, test_predictions)
     assert_metric_eq(result, expected)


### PR DESCRIPTION
Adds average precision and mean average precision for boxes/polygons.

Adds more informative docstring for `PolygonIOU`, `PolygonPrecision`, and `PolygonRecall`.