### PR TITLE
Make shapely installation optional via metrics flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ jobs:
       - run:
           name: Install Environment Dependencies
           command: | # install dependencies
-            apt-get -y install curl
-            pip install --upgrade pip 
+            apt-get -y install curl libgeos-dev
+            pip install --upgrade pip
             pip install poetry
-            poetry install
+            poetry install -E metrics
 
       - run:
           name: Black Formatting Check # Only validation, without re-formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run:
           name: Install Environment Dependencies
           command: | # install dependencies
+            apt-get update
             apt-get -y install curl libgeos-dev
             pip install --upgrade pip
             pip install poetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.5.3) - 2021-01-19
+
+### Fixed
+- Added optional `scale-nucleus[metrics]` extra to install Validate metrics dependencies. 
+
+## [0.5.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.5.2) - 2021-01-19
+
+### Added
+- dataset.delete_scene allows for deletion of a single scene.
+
 ## [0.5.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.5.1) - 2021-01-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -156,3 +156,22 @@ cd docs
 sphinx-autobuild . ./_build/html --watch ../nucleus
 ```
 `sphinx-autobuild` will spin up a server on localhost (port 8000 by default) that will watch for and automatically rebuild a version of the API reference based on your local docstring changes.
+
+
+## Custom Metrics used in Scale Validate
+
+To install the availalbe metrics for Scale Validate add the optional `metrics` extra.
+Note that you might need to install a local GEOS package.
+
+```bash
+#Mac OS
+brew install geos
+# Ubuntu/Debian flavors
+apt-get install libgeos-dev
+```
+
+`pip install scale-nucleus[metrics]`
+
+To develop it locally use
+
+`poetry install --extra metrics`

--- a/nucleus/metrics/__init__.py
+++ b/nucleus/metrics/__init__.py
@@ -24,5 +24,6 @@ except ModuleNotFoundError as e:
     else:
         platform_specific_msg = "GEOS package will need to be installed see (https://trac.osgeo.org/geos/)"
     raise ModuleNotFoundError(
-        f"Module 'shapely' not found. Install optionally with `scale-nucleus[metrics]`. {platform_specific_msg}"
+        f"Module 'shapely' not found. Install optionally with `scale-nucleus[metrics]` or when developing "
+        f"`poetry install -E metrics`. {platform_specific_msg}"
     ) from e

--- a/nucleus/metrics/__init__.py
+++ b/nucleus/metrics/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 from .base import Metric, MetricResult
 from .polygon_metrics import (
     PolygonIOU,
@@ -5,3 +7,22 @@ from .polygon_metrics import (
     PolygonPrecision,
     PolygonRecall,
 )
+
+try:
+    import shapely
+except ModuleNotFoundError as e:
+    if sys.platform.startswith("darwin"):
+        platform_specific_msg = (
+            "Depending on Python environment used GEOS might need to be installed via "
+            "`brew install geos`."
+        )
+    elif sys.platform.startswith("linux"):
+        platform_specific_msg = (
+            "Depending on Python environment used GEOS might need to be installed via "
+            "system package `libgeos-dev`."
+        )
+    else:
+        platform_specific_msg = "GEOS package will need to be installed see (https://trac.osgeo.org/geos/)"
+    raise ModuleNotFoundError(
+        f"Module 'shapely' not found. Install optionally with `scale-nucleus[metrics]`. {platform_specific_msg}"
+    ) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pydantic = "^1.8.2"
 isort = "^5.10.1"
 numpy = "^1.19.5"
 scipy = "^1.5.4"
-Shapely = "^1.8.0"
+Shapely = { version = ">=1.8.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.5"
@@ -61,6 +61,9 @@ sphinx-autobuild = "^2021.3.14"
 furo = "^2021.10.9"
 sphinx-autoapi = "^1.8.4"
 pytest-xdist = "^2.5.0"
+
+[tool.poetry.extras]
+metrics = ["Shapely"]
 
 
 [tool.pytest.ini_options]

--- a/tests/metrics/__init__.py
+++ b/tests/metrics/__init__.py
@@ -1,0 +1,9 @@
+import pytest
+
+try:
+    import shapely
+except ModuleNotFoundError:
+    pytest.skip(
+        "Skipping metrics tests (to run install with poetry install -E metrics)",
+        allow_module_level=True,
+    )

--- a/tests/metrics/test_polygon_metrics.py
+++ b/tests/metrics/test_polygon_metrics.py
@@ -1,9 +1,10 @@
 from copy import deepcopy
 
+import pkg_resources
 import pytest
 
 from nucleus.metrics import PolygonIOU, PolygonPrecision, PolygonRecall
-from nucleus.metrics.base import Metric, MetricResult
+from nucleus.metrics.base import MetricResult
 from tests.metrics.helpers import (
     TEST_ANNOTATION_LIST,
     TEST_BOX_ANNOTATION_LIST,


### PR DESCRIPTION
Shapely seems to be a nice package for polygon metrics. It was a little involved for me to switch it out right now so I opted to make the dependency optional. It can now be installed with:

`pip install scale-nucleus[metrics]`

or locally

`poetry install -E metrics`

By default the shapely package is not installed. 

I think this is a fine solution for now, we can choose to remove the optional dependency in the future and change out `Shapely` for something else. 
