### PR TITLE
Delete Taxonomy

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -375,8 +375,8 @@ class NucleusClient:
         """
         warnings.warn(
             "The default create_dataset('dataset_name', ...) method without the is_scene parameter will be deprecated soon in favor of providing the is_scene parameter explicitly. "
-            "Please make sure to create a dataset with either create_dataset('dataset_name', is_scene=True, ...) to upload "
-            "DatasetItems or create_dataset('dataset_name', is_scene=False, ...) to upload "
+            "Please make sure to create a dataset with either create_dataset('dataset_name', is_scene=False, ...) to upload "
+            "DatasetItems or create_dataset('dataset_name', is_scene=True, ...) to upload "
             "LidarScenes.",
             DeprecationWarning,
         )

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -953,6 +953,24 @@ class Dataset:
             requests_command=requests.post,
         )
 
+    def delete_taxonomy(
+        self,
+        taxonomy_name: str,
+    ):
+        """Deletes the given taxonomy.
+
+        Parameters:
+            taxonomy_name: The name of the taxonomy.
+
+        Returns:
+            Returns a response with dataset_id, taxonomy_name and status of the delete taxonomy operation.
+        """
+        return self._client.make_request(
+            {},
+            f"dataset/{self.id}/taxonomy/{taxonomy_name}/delete_taxonomy",
+            requests.delete,
+        )
+
     def items_and_annotations(
         self,
     ) -> List[Dict[str, Union[DatasetItem, Dict[str, List[Annotation]]]]]:

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -992,7 +992,7 @@ class Dataset:
         """
         return self._client.make_request(
             {},
-            f"dataset/{self.id}/taxonomy/{taxonomy_name}/delete_taxonomy",
+            f"dataset/{self.id}/taxonomy/{taxonomy_name}",
             requests.delete,
         )
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -982,6 +982,8 @@ class Dataset:
     ):
         """Deletes the given taxonomy.
 
+        All annotations and predictions associated with the taxonomy will be deleted as well.
+
         Parameters:
             taxonomy_name: The name of the taxonomy.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.4.2"
+version = "0.4.3"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -5,7 +5,7 @@ from .helpers import TEST_DATASET_NAME
 
 @pytest.fixture()
 def dataset(CLIENT):
-    ds = CLIENT.create_dataset(TEST_DATASET_NAME)
+    ds = CLIENT.create_dataset(TEST_DATASET_NAME, is_scene=False)
 
     ds.add_taxonomy(
         "[Pytest] taxonomy",
@@ -62,3 +62,13 @@ def test_duplicate_taxonomy_update(dataset):
     assert response["dataset_id"] == dataset.id
     assert response["taxonomy_name"] == "[Pytest] taxonomy"
     assert response["status"] == "Taxonomy updated"
+
+
+def test_delete_taxonomy(dataset):
+    response = dataset.delete_taxonomy(
+        "[Pytest] taxonomy",
+    )
+
+    assert response["dataset_id"] == dataset.id
+    assert response["taxonomy_name"] == "[Pytest] taxonomy"
+    assert response["status"] == "Taxonomy deleted"

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -71,4 +71,4 @@ def test_delete_taxonomy(dataset):
 
     assert response["dataset_id"] == dataset.id
     assert response["taxonomy_name"] == "[Pytest] taxonomy"
-    assert response["status"] == "Taxonomy deleted"
+    assert response["status"] == "Taxonomy successfully deleted"


### PR DESCRIPTION
Added support for deleting taxonomies. Tested deletion of taxonomies with code in scaleapi/scaleapi#35536.

Also fixed deprecation message for `create_dataset`.

## Shortcut Ticket

[[sc-360153]](https://app.shortcut.com/scaleai/story/360153)