### PR TITLE
Remove body on GET requests for ScaleGov

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -943,7 +943,7 @@ class NucleusClient:
         """
         if payload is None:
             payload = {}
-        if requests_command == requests.get:
+        if requests_command is requests.get:
             payload = None
         return self._connection.make_request(payload, route, requests_command)  # type: ignore
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -943,6 +943,8 @@ class NucleusClient:
         """
         if payload is None:
             payload = {}
+        if requests_command == requests.get:
+            payload = None
         return self._connection.make_request(payload, route, requests_command)  # type: ignore
 
     def handle_bad_response(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.5.4"
+version = "0.5.5"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Our ScaleGov environment has an AWS WAF (Web Application Firewall) that errors out on any GET request that has a json parameter (for some reason or another). GET requests really shouldn't have a body anyway so it shouldn't matter.