### PR TITLE
Better COLAB installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.6.0"
+version = "0.6.1"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]
@@ -38,12 +38,10 @@ tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
 aiohttp = "^3.7.4"
 nest-asyncio = "^1.5.1"
-Sphinx = "^4.2.0"
 pydantic = "^1.8.2"
-isort = "^5.10.1"
 numpy = "^1.19.5"
-scipy = "^1.5.4"
-click = "^8.0.3"
+scipy = ">=1.4.1"  # NOTE: COLAB has 1.4.1 and has problems updating
+click = ">=7.1.2,<9.0"  # NOTE: COLAB has 7.1.2 and has problems updating
 rich = "^10.15.2"
 shellingham = "^1.4.0"
 
@@ -57,6 +55,7 @@ mypy = "^0.812"
 coverage = "^5.5"
 pre-commit = "^2.12.1"
 jupyterlab = "^3.1.10"
+isort = "^5.10.1"
 absl-py = "^0.13.0"
 Sphinx = "^4.2.0"
 sphinx-autobuild = "^2021.3.14"


### PR DESCRIPTION
COLAB has some pre-installed packages that cause problems when you update. You have to frequently restart the runtime and that makes for a very broken experience.

This allows click and scipy to be of the pre-installed version ... this gets around the problems mentioned. We don't use any specific click 8.0> functionality for now and have limited exposure on the scipy front. The used method has been there since 0.17.