### PR TITLE
XFAIL flaky `nu datasets delete` test

### DIFF
--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 from click.testing import CliRunner
 
 from cli.datasets import datasets, delete_dataset, list_datasets
@@ -21,6 +22,9 @@ def test_invoke_dataset_list(cli_datasets):
         assert dataset.id in result.output
 
 
+@pytest.mark.xfail(
+    reason="Dataset delete is flaky -> The deleted dataset still shows up."
+)
 def test_invoke_dataset_delete(CLIENT, cli_datasets):
     dataset_name = "[PyTest] To delete"
     dataset = CLIENT.create_dataset(dataset_name, is_scene=False)
@@ -29,7 +33,7 @@ def test_invoke_dataset_delete(CLIENT, cli_datasets):
     assert result.exception is None
     assert result.exit_code == 0
     # NOTE: Takes a bit of time to delete -> Sleep
-    time.sleep(1)
+    time.sleep(2)
     list_result = runner.invoke(list_datasets)  # type:ignore
     assert dataset.id not in list_result.output
 


### PR DESCRIPTION
There seems to be flakiness in deleting a dataset and it still being listed a couple of seconds later. I'm marking this as XFAIL -> Which runs the test but doesn't fail the suite.