### PR TITLE
Delete datasets after every creation

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -15,7 +15,7 @@ def runner():
 
 
 @pytest.fixture(scope="module")
-def cli_datasets(CLIENT):
+def module_scope_datasets(CLIENT):
     test_datasets = []
     for i in range(3):
         dataset_name = f"[PyTest] CLI {i} {get_uuid()}"
@@ -28,8 +28,15 @@ def cli_datasets(CLIENT):
         CLIENT.delete_dataset(test_dataset.id)
 
 
+@pytest.fixture(scope="function")
+def function_scope_dataset(CLIENT):
+    dataset = CLIENT.create_dataset(f"[PyTest] Dataset {get_uuid()}")
+    yield dataset
+    CLIENT.delete_dataset(dataset.id)
+
+
 @pytest.fixture(scope="module")
-def cli_models(CLIENT):
+def module_scope_models(CLIENT):
     models = []
     for i in range(3):
         model_name = "[PyTest] Model {i}"
@@ -42,13 +49,13 @@ def cli_models(CLIENT):
 
 
 @pytest.fixture(scope="module")
-def populated_dataset(cli_datasets):
-    yield cli_datasets[0]
+def populated_dataset(module_scope_datasets):
+    yield module_scope_datasets[0]
 
 
 @pytest.fixture(scope="module")
-def model(cli_models):
-    yield cli_models[0]
+def model(module_scope_models):
+    yield module_scope_models[0]
 
 
 @pytest.fixture(scope="module")

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -6,26 +6,26 @@ from click.testing import CliRunner
 from cli.datasets import datasets, delete_dataset, list_datasets
 
 
-def test_invoke_dataset_outputs_list(cli_datasets):
+def test_invoke_dataset_outputs_list(module_scope_datasets):
     runner = CliRunner()
     result = runner.invoke(datasets)  # type: ignore
     assert result.exception is None
-    for dataset in cli_datasets:
+    for dataset in module_scope_datasets:
         assert dataset.id in result.output
 
 
-def test_invoke_dataset_list(cli_datasets):
+def test_invoke_dataset_list(module_scope_datasets):
     runner = CliRunner()
     result = runner.invoke(list_datasets)  # type: ignore
     assert result.exception is None
-    for dataset in cli_datasets:
+    for dataset in module_scope_datasets:
         assert dataset.id in result.output
 
 
 @pytest.mark.xfail(
     reason="Dataset delete is flaky -> The deleted dataset still shows up."
 )
-def test_invoke_dataset_delete(CLIENT, cli_datasets):
+def test_invoke_dataset_delete(CLIENT, module_scope_datasets):
     dataset_name = "[PyTest] To delete"
     dataset = CLIENT.create_dataset(dataset_name, is_scene=False)
     runner = CliRunner()
@@ -38,9 +38,9 @@ def test_invoke_dataset_delete(CLIENT, cli_datasets):
     assert dataset.id not in list_result.output
 
 
-def test_invoke_dataset_delete_wrong_confirmation(cli_datasets):
+def test_invoke_dataset_delete_wrong_confirmation(module_scope_datasets):
     runner = CliRunner()
-    dataset_to_not_delete = cli_datasets[0]
+    dataset_to_not_delete = module_scope_datasets[0]
     result = runner.invoke(delete_dataset, ["--id", str(dataset_to_not_delete.id)], input="DEL")  # type: ignore
     assert result.exit_code != 0
     list_result = runner.invoke(list_datasets)  # type:ignore

--- a/tests/cli/test_jobs.py
+++ b/tests/cli/test_jobs.py
@@ -19,3 +19,4 @@ def test_list_jobs(CLIENT, runner):
     time.sleep(0.5)
     assert result.exception is None
     assert result.exit_code == 0
+    CLIENT.delete_dataset(dataset.id)

--- a/tests/cli/test_jobs.py
+++ b/tests/cli/test_jobs.py
@@ -11,12 +11,11 @@ def test_invoke_jobs(runner):
     assert result.exit_code == 0
 
 
-def test_list_jobs(CLIENT, runner):
-    dataset = CLIENT.create_dataset(f"[PyTest] Dataset {get_uuid()}")
+def test_list_jobs(CLIENT, runner, function_scope_dataset):
+    dataset = function_scope_dataset
     items = make_dataset_items()
     dataset.append(items, asynchronous=True)
     result = runner.invoke(list_jobs)
     time.sleep(0.5)
     assert result.exception is None
     assert result.exit_code == 0
-    CLIENT.delete_dataset(dataset.id)

--- a/tests/cli/test_models.py
+++ b/tests/cli/test_models.py
@@ -3,17 +3,17 @@ from click.testing import CliRunner
 from cli.models import list_models, models
 
 
-def test_invoke_models(runner, cli_models):
+def test_invoke_models(runner, module_scope_models):
     result = runner.invoke(models)  # type: ignore
     assert result.exception is None
     assert result.exit_code == 0
-    for model in cli_models:
+    for model in module_scope_models:
         assert model.id in result.output
 
 
-def test_invoke_models_list(runner, cli_models):
+def test_invoke_models_list(runner, module_scope_models):
     result = runner.invoke(list_models)  # type: ignore
     assert result.exception is None
     assert result.exit_code == 0
-    for model in cli_models:
+    for model in module_scope_models:
         assert model.id in result.output

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -77,7 +77,9 @@ def dataset(CLIENT):
 
 @pytest.fixture()
 def dataset_scene(CLIENT):
-    CLIENT.create_dataset(TEST_DATASET_NAME, is_scene=True)
+    ds = CLIENT.create_dataset(TEST_DATASET_NAME, is_scene=True)
+    yield ds
+    CLIENT.delete_dataset(ds.id)
 
 
 def make_dataset_items():


### PR DESCRIPTION
There were a couple of places where datasets weren't being cleaned up after test runs. This makes sure we aren't littering.