### PR TITLE
Skip list slices test for CLI

### DIFF
--- a/tests/cli/test_slices.py
+++ b/tests/cli/test_slices.py
@@ -21,6 +21,9 @@ def test_invoke_slices(runner):
 
 
 @pytest.mark.integration
+@pytest.mark.skip(
+    reason="Slices listing times out for Nucleus PyTest account in CircleCI"
+)
 def test_invoke_slices_list(runner, cli_slices):
     runner = CliRunner()
     result = runner.invoke(list_slices)  # type: ignore


### PR DESCRIPTION
Skips a CLI test that seems to be timing out. The slices list calls are very slow due to it growing linearly with slices and sounds like the user running the pytest has so many that it consistently times out (longer than 10 mins).