### PR TITLE
Support creating of model bundles from a directory

### DIFF
--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -133,8 +133,8 @@ class DeployClient:
             load_model_fn_module_path: A python module path within base_path for a function that returns a model. The output feeds into
                 the function located at load_predict_fn_module_path.
         """
-        with open(requirements_path, "r", encoding="utf-8") as f:
-            requirements = f.read().splitlines()
+        with open(requirements_path, "r", encoding="utf-8") as req_f:
+            requirements = req_f.read().splitlines()
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -150,8 +150,8 @@ class DeployClient:
                     base_dir=base_dir,
                 ),
                 "rb",
-            ) as f:
-                data = f.read()
+            ) as zip_f:
+                data = zip_f.read()
         finally:
             shutil.rmtree(tmpdir)
 

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -118,11 +118,18 @@ class DeployClient:
         with open(requirements_path, "r") as f:
             requirements = f.read().splitlines()
 
-
         tmpdir = tempfile.mkdtemp()
         try:
             tmparchive = os.path.join(tmpdir, "bundle")
-            data = open(shutil.make_archive(tmparchive, "zip", base_path), "rb").read()
+            root_dir = os.path.dirname(base_path)
+            base_dir = os.path.basename(base_path)
+
+            data = open(shutil.make_archive(
+                base_name=tmparchive,
+                format="zip",
+                root_dir=root_dir,
+                base_dir=base_dir
+            ), "rb").read()
             model_bundle_url = self.connection.post({}, MODEL_BUNDLE_SIGNED_URL_PATH)
             s3_path = model_bundle_url["signedUrl"]
 

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -110,7 +110,7 @@ class DeployClient:
         requirements_path: str,
         env_params: Dict[str, str],
         load_predict_fn_module_path: str,
-        load_model_fn_module_path: str
+        load_model_fn_module_path: str,
     ) -> ModelBundle:
         """
         Packages up code from a local filesystem folder and uploads that as a bundle to Scale Deploy.
@@ -142,23 +142,32 @@ class DeployClient:
             root_dir = os.path.dirname(base_path)
             base_dir = os.path.basename(base_path)
 
-            data = open(shutil.make_archive(
-                base_name=tmparchive,
-                format="zip",
-                root_dir=root_dir,
-                base_dir=base_dir
-            ), "rb").read()
+            data = open(
+                shutil.make_archive(
+                    base_name=tmparchive,
+                    format="zip",
+                    root_dir=root_dir,
+                    base_dir=base_dir,
+                ),
+                "rb",
+            ).read()
         finally:
             shutil.rmtree(tmpdir)
 
-        model_bundle_url = self.connection.post({}, MODEL_BUNDLE_SIGNED_URL_PATH)
+        model_bundle_url = self.connection.post(
+            {}, MODEL_BUNDLE_SIGNED_URL_PATH
+        )
         s3_path = model_bundle_url["signedUrl"]
 
         # NOTE: Right now, the signedUrl endpoint returns a path that ends with a UUID,
         # without the ability to specify a suffix (i.e. a file extension). This means that
         # we'll have to find another means of distinguishing file types.
-        raw_bundle_url = f"s3://{model_bundle_url['bucket']}/{model_bundle_url['key']}"
-        logger.info(f"create_model_bundle_from_dir: raw_bundle_url={raw_bundle_url}")
+        raw_bundle_url = (
+            f"s3://{model_bundle_url['bucket']}/{model_bundle_url['key']}"
+        )
+        logger.info(
+            f"create_model_bundle_from_dir: raw_bundle_url={raw_bundle_url}"
+        )
 
         requests.put(s3_path, data=data)
 
@@ -177,7 +186,7 @@ class DeployClient:
                 requirements=requirements,
                 env_params=env_params,
             ),
-            route="model_bundle"
+            route="model_bundle",
         )
         return ModelBundle(model_bundle_name)
 

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -108,7 +108,6 @@ class DeployClient:
         model_bundle_name: str,
         base_path: str,
         requirements_path: str,
-        base_image: str,
         env_params: Dict[str, str],
         load_predict_fn_module_path: str,
         load_model_fn_module_path: str

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -145,7 +145,6 @@ class DeployClient:
         requests.put(s3_path, data=data)
 
         bundle_metadata = {
-            "type": "zip",
             "load_predict_fn_module_path": load_predict_fn_module_path,
             "load_model_fn_module_path": load_model_fn_module_path,
             "base_dir": base_dir,
@@ -153,6 +152,7 @@ class DeployClient:
 
         self.connection.post(
             payload=dict(
+                type="zip",
                 bundle_name=model_bundle_name,
                 location=raw_bundle_url,
                 bundle_metadata=bundle_metadata,
@@ -266,6 +266,7 @@ class DeployClient:
 
         self.connection.post(
             payload=dict(
+                type="cloudpickle",
                 bundle_name=model_bundle_name,
                 location=raw_bundle_url,
                 bundle_metadata=bundle_metadata,

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -1,10 +1,10 @@
 import inspect
 import logging
 import os
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
-
 import shutil
 import tempfile
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+
 import cloudpickle
 import requests
 

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -170,7 +170,7 @@ class DeployClient:
 
         self.connection.post(
             payload=dict(
-                type="zip",
+                packaging_type="zip",
                 bundle_name=model_bundle_name,
                 location=raw_bundle_url,
                 bundle_metadata=bundle_metadata,
@@ -284,7 +284,7 @@ class DeployClient:
 
         self.connection.post(
             payload=dict(
-                type="cloudpickle",
+                packaging_type="cloudpickle",
                 bundle_name=model_bundle_name,
                 location=raw_bundle_url,
                 bundle_metadata=bundle_metadata,

--- a/nucleus/deploy/client.py
+++ b/nucleus/deploy/client.py
@@ -3,10 +3,10 @@ import logging
 import os
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
-import cloudpickle
-import requests
 import shutil
 import tempfile
+import cloudpickle
+import requests
 
 from nucleus.connection import Connection
 from nucleus.deploy.constants import (
@@ -133,7 +133,7 @@ class DeployClient:
             load_model_fn_module_path: A python module path within base_path for a function that returns a model. The output feeds into
                 the function located at load_predict_fn_module_path.
         """
-        with open(requirements_path, "r") as f:
+        with open(requirements_path, "r", encoding="utf-8") as f:
             requirements = f.read().splitlines()
 
         tmpdir = tempfile.mkdtemp()
@@ -142,7 +142,7 @@ class DeployClient:
             root_dir = os.path.dirname(base_path)
             base_dir = os.path.basename(base_path)
 
-            data = open(
+            with open(
                 shutil.make_archive(
                     base_name=tmparchive,
                     format="zip",
@@ -150,7 +150,8 @@ class DeployClient:
                     base_dir=base_dir,
                 ),
                 "rb",
-            ).read()
+            ) as f:
+                data = f.read()
         finally:
             shutil.rmtree(tmpdir)
 
@@ -163,10 +164,11 @@ class DeployClient:
         # without the ability to specify a suffix (i.e. a file extension). This means that
         # we'll have to find another means of distinguishing file types.
         raw_bundle_url = (
-            f"s3://{model_bundle_url['bucket']}/{model_bundle_url['key']}"
+            "s3://{model_bundle_url['bucket']}/{model_bundle_url['key']}"
         )
         logger.info(
-            f"create_model_bundle_from_dir: raw_bundle_url={raw_bundle_url}"
+            "create_model_bundle_from_dir: raw_bundle_url=%s",
+            raw_bundle_url,
         )
 
         requests.put(s3_path, data=data)


### PR DESCRIPTION
Allows users to create model bundles from a local zip file. Here's an example invocation that I tested:

```python3
model_bundle = deploy_client.create_model_bundle_from_dir(
    model_bundle_name="yi-bundle-dir-test6",
    base_path="/Users/yixu/projects/models/lidar",
    requirements_path="/Users/yixu/projects/models/lidar/requirements.txt",
    env_params={"framework_type": "pytorch", "pytorch_image_tag": "1.7.1-cuda11.0-cudnn8-runtime"}, 
    load_predict_fn_module_path="lidar.segmentation.tasks.load_predict_fn", 
    load_model_fn_module_path="lidar.segmentation.models.decorator.get_segmentation_model"
)
```