### PR TITLE
Add id fields to Annotations and Predictions for traceability

### DIFF
--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -134,6 +134,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
         embedding_vector: Custom embedding vector for this object annotation.
             If any custom object embeddings have been uploaded previously to this dataset,
             this vector must match the dimensions of the previously ingested vectors.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -236,6 +237,7 @@ class LineAnnotation(Annotation):
             attach to this annotation.  Strings, floats and ints are supported best
             by querying and insights features within Nucleus. For more details see
             our `metadata guide <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -322,6 +324,7 @@ class PolygonAnnotation(Annotation):
         embedding_vector: Custom embedding vector for this object annotation.
             If any custom object embeddings have been uploaded previously to this dataset,
             this vector must match the dimensions of the previously ingested vectors.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -456,6 +459,7 @@ class KeypointsAnnotation(Annotation):
             attach to this annotation.  Strings, floats and ints are supported best
             by querying and insights features within Nucleus. For more details see
             our `metadata guide <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -565,6 +569,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
           annotation.  Strings, floats and ints are supported best by querying
           and insights features within Nucleus. For more details see our `metadata
           guide <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -632,6 +637,7 @@ class Segment:
           Strings, floats and ints are supported best by querying and insights
           features within Nucleus. For more details see our `metadata guide
           <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str
@@ -715,6 +721,7 @@ class SegmentationAnnotation(Annotation):
           is passed to :meth:`Dataset.annotate`, in which case it will be overwritten.
           Storing a custom ID here may be useful in order to tie this annotation
           to an external database, and its value will be returned for any export.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     mask_url: str
@@ -812,6 +819,7 @@ class CategoryAnnotation(Annotation):
           Strings, floats and ints are supported best by querying and insights
           features within Nucleus. For more details see our `metadata guide
           <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Annotations from the server.
     """
 
     label: str

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -15,6 +15,7 @@ from .constants import (
     EMBEDDING_VECTOR_KEY,
     GEOMETRY_KEY,
     HEIGHT_KEY,
+    ID_KEY,
     INDEX_KEY,
     KEYPOINTS_KEY,
     KEYPOINTS_NAMES_KEY,
@@ -50,6 +51,7 @@ class Annotation:
     """
 
     reference_id: str
+    id: Optional[str]
 
     @classmethod
     def from_json(cls, payload: dict):
@@ -143,6 +145,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
     annotation_id: Optional[str] = None
     metadata: Optional[Dict] = None
     embedding_vector: Optional[list] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -162,6 +165,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -239,6 +243,7 @@ class LineAnnotation(Annotation):
     reference_id: str
     annotation_id: Optional[str] = None
     metadata: Optional[Dict] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -267,6 +272,7 @@ class LineAnnotation(Annotation):
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -324,6 +330,7 @@ class PolygonAnnotation(Annotation):
     annotation_id: Optional[str] = None
     metadata: Optional[Dict] = None
     embedding_vector: Optional[list] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -353,6 +360,7 @@ class PolygonAnnotation(Annotation):
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -457,6 +465,7 @@ class KeypointsAnnotation(Annotation):
     reference_id: str
     annotation_id: Optional[str] = None
     metadata: Optional[Dict] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata or {}
@@ -483,6 +492,7 @@ class KeypointsAnnotation(Annotation):
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -564,6 +574,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
     reference_id: str
     annotation_id: Optional[str] = None
     metadata: Optional[Dict] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -579,6 +590,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -709,6 +721,7 @@ class SegmentationAnnotation(Annotation):
     annotations: List[Segment]
     reference_id: str
     annotation_id: Optional[str] = None
+    id: Optional[str] = None
     # metadata: Optional[dict] = None # TODO(sc: 422637)
 
     def __post_init__(self):
@@ -727,6 +740,7 @@ class SegmentationAnnotation(Annotation):
             ],
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
+            id=payload.get(ID_KEY, None),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
 
@@ -804,6 +818,7 @@ class CategoryAnnotation(Annotation):
     reference_id: str
     taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -815,6 +830,7 @@ class CategoryAnnotation(Annotation):
             reference_id=payload[REFERENCE_ID_KEY],
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -838,6 +854,7 @@ class MultiCategoryAnnotation(Annotation):
     reference_id: str
     taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = None
+    id: Optional[str] = None
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -849,6 +866,7 @@ class MultiCategoryAnnotation(Annotation):
             reference_id=payload[REFERENCE_ID_KEY],
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
+            id=payload.get(ID_KEY, None),
         )
 
     def to_payload(self) -> dict:

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -113,8 +113,8 @@ def _iou_assignments_for_same_reference_id(
         logging.warning(
             "Invalid polygons for dataset items: %s Annotations:%s, predictions: %s",
             invalid_dataset_ids,
-            [a.annotation_id for a in invalid_anns],
-            [p.annotation_id for p in invalid_preds],
+            [a.id for a in invalid_anns],
+            [p.id for p in invalid_preds],
         )
 
     # Compute IoU matrix and set IoU values below the threshold to 0.

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -31,6 +31,7 @@ from .constants import (
     EMBEDDING_VECTOR_KEY,
     GEOMETRY_KEY,
     HEIGHT_KEY,
+    ID_KEY,
     KEYPOINTS_KEY,
     KEYPOINTS_NAMES_KEY,
     KEYPOINTS_SKELETON_KEY,
@@ -128,6 +129,7 @@ class SegmentationPrediction(SegmentationAnnotation):
             ],
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
+            id=payload.get(ID_KEY, None),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
 
@@ -179,6 +181,7 @@ class BoxPrediction(BoxAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
@@ -190,6 +193,7 @@ class BoxPrediction(BoxAnnotation):
             annotation_id=annotation_id,
             metadata=metadata,
             embedding_vector=embedding_vector,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -218,6 +222,7 @@ class BoxPrediction(BoxAnnotation):
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 
@@ -253,6 +258,7 @@ class LinePrediction(LineAnnotation):
         annotation_id: Optional[str] = None,
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
@@ -260,6 +266,7 @@ class LinePrediction(LineAnnotation):
             reference_id=reference_id,
             annotation_id=annotation_id,
             metadata=metadata,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -286,6 +293,7 @@ class LinePrediction(LineAnnotation):
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 
@@ -325,6 +333,7 @@ class PolygonPrediction(PolygonAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
@@ -333,6 +342,7 @@ class PolygonPrediction(PolygonAnnotation):
             annotation_id=annotation_id,
             metadata=metadata,
             embedding_vector=embedding_vector,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -360,6 +370,7 @@ class PolygonPrediction(PolygonAnnotation):
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 
@@ -400,6 +411,7 @@ class KeypointsPrediction(KeypointsAnnotation):
         annotation_id: Optional[str] = None,
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
@@ -409,6 +421,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             reference_id=reference_id,
             annotation_id=annotation_id,
             metadata=metadata,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -437,6 +450,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 
@@ -475,6 +489,7 @@ class CuboidPrediction(CuboidAnnotation):
         annotation_id: Optional[str] = None,
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
@@ -484,6 +499,7 @@ class CuboidPrediction(CuboidAnnotation):
             reference_id=reference_id,
             annotation_id=annotation_id,
             metadata=metadata,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -510,6 +526,7 @@ class CuboidPrediction(CuboidAnnotation):
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 
@@ -540,12 +557,14 @@ class CategoryPrediction(CategoryAnnotation):
         confidence: Optional[float] = None,
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
+        id: Optional[str] = None,  # pylint: disable=redefined-builtin
     ):
         super().__init__(
             label=label,
             taxonomy_name=taxonomy_name,
             reference_id=reference_id,
             metadata=metadata,
+            id=id,
         )
         self.confidence = confidence
         self.class_pdf = class_pdf
@@ -568,6 +587,7 @@ class CategoryPrediction(CategoryAnnotation):
             confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
+            id=payload.get(ID_KEY, None),
         )
 
 

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -117,6 +117,7 @@ class SegmentationPrediction(SegmentationAnnotation):
           is passed to :meth:`Dataset.annotate`, in which case it will be overwritten.
           Storing a custom ID here may be useful in order to tie this annotation
           to an external database, and its value will be returned for any export.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     @classmethod
@@ -166,6 +167,7 @@ class BoxPrediction(BoxAnnotation):
         embedding_vector (Optional[List]): Custom embedding vector for this object annotation.
             If any custom object embeddings have been uploaded previously to this dataset,
             this vector must match the dimensions of the previously ingested vectors.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(
@@ -247,6 +249,7 @@ class LinePrediction(LineAnnotation):
             annotation. Each value should be between 0 and 1 (inclusive), and sum up to
             1 as a complete distribution. This can be useful for computing entropy to
             surface places where the model is most uncertain.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(
@@ -321,6 +324,7 @@ class PolygonPrediction(PolygonAnnotation):
         embedding_vector: Custom embedding vector for this object annotation.
             If any custom object embeddings have been uploaded previously to this dataset,
             this vector must match the dimensions of the previously ingested vectors.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(
@@ -398,6 +402,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             annotation. Each value should be between 0 and 1 (inclusive), and sum up to
             1 as a complete distribution. This can be useful for computing entropy to
             surface places where the model is most uncertain.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(
@@ -476,6 +481,7 @@ class CuboidPrediction(CuboidAnnotation):
             annotation. Each value should be between 0 and 1 (inclusive), and sum up to
             1 as a complete distribution. This can be useful for computing entropy to
             surface places where the model is most uncertain.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(
@@ -547,6 +553,7 @@ class CategoryPrediction(CategoryAnnotation):
             Strings, floats and ints are supported best by querying and insights
             features within Nucleus. For more details see our `metadata guide
             <https://nucleus.scale.com/docs/upload-metadata>`_.
+        id: Unique Nucleus generated ID. This field is populated when loading Predictions from the server.
     """
 
     def __init__(


### PR DESCRIPTION
When loading annotations and predictions that have assigned IDs there was no way of searching for those in the frontend. This adds and ID field that is populated when loading Annotations and Predictions from server.