### PR TITLE
Add shapely import guards to make sure tests run without extras

### DIFF
--- a/nucleus/metrics/cuboid_utils.py
+++ b/nucleus/metrics/cuboid_utils.py
@@ -6,27 +6,9 @@ import numpy as np
 try:
     from shapely.geometry import Polygon
 except ModuleNotFoundError:
-    import sys
+    from .shapely_not_installed import ShapelyNotInstalled
 
-    class Polygon:  # type: ignore
-        def __init__(self, *args, **kwargs):
-            """Object to make sure we only raise errors if actually trying to use shapely"""
-            if sys.platform.startswith("darwin"):
-                platform_specific_msg = (
-                    "Depending on Python environment used GEOS might need to be installed via "
-                    "`brew install geos`."
-                )
-            elif sys.platform.startswith("linux"):
-                platform_specific_msg = (
-                    "Depending on Python environment used GEOS might need to be installed via "
-                    "system package `libgeos-dev`."
-                )
-            else:
-                platform_specific_msg = "GEOS package will need to be installed see (https://trac.osgeo.org/geos/)"
-            raise ModuleNotFoundError(
-                f"Module 'shapely' not found. Install optionally with `scale-nucleus[shapely]` or when developing "
-                f"`poetry install -E shapely`. {platform_specific_msg}"
-            )
+    Polygon = ShapelyNotInstalled
 
 
 from nucleus.annotation import CuboidAnnotation

--- a/nucleus/metrics/custom_types.py
+++ b/nucleus/metrics/custom_types.py
@@ -1,0 +1,22 @@
+from typing import TypeVar
+
+from nucleus import (
+    BoxAnnotation,
+    BoxPrediction,
+    PolygonAnnotation,
+    PolygonPrediction,
+)
+
+BoxOrPolygonPrediction = TypeVar(
+    "BoxOrPolygonPrediction", BoxPrediction, PolygonPrediction
+)
+BoxOrPolygonAnnotation = TypeVar(
+    "BoxOrPolygonAnnotation", BoxAnnotation, PolygonAnnotation
+)
+BoxOrPolygonAnnoOrPred = TypeVar(
+    "BoxOrPolygonAnnoOrPred",
+    BoxAnnotation,
+    PolygonAnnotation,
+    BoxPrediction,
+    PolygonPrediction,
+)

--- a/nucleus/metrics/filters.py
+++ b/nucleus/metrics/filters.py
@@ -2,7 +2,8 @@ from typing import List
 
 from nucleus.prediction import PredictionList
 
-from .polygon_utils import BoxOrPolygonAnnoOrPred, polygon_annotation_to_shape
+from .custom_types import BoxOrPolygonAnnoOrPred
+from .polygon_utils import polygon_annotation_to_shape
 
 
 def polygon_area_filter(

--- a/nucleus/metrics/polygon_metrics.py
+++ b/nucleus/metrics/polygon_metrics.py
@@ -8,12 +8,11 @@ from nucleus.annotation import AnnotationList, BoxAnnotation, PolygonAnnotation
 from nucleus.prediction import BoxPrediction, PolygonPrediction, PredictionList
 
 from .base import Metric, ScalarResult
+from .custom_types import BoxOrPolygonAnnotation, BoxOrPolygonPrediction
 from .filtering import ListOfAndFilters, ListOfOrAndFilters
 from .filters import confidence_filter, polygon_label_filter
 from .metric_utils import compute_average_precision
 from .polygon_utils import (
-    BoxOrPolygonAnnotation,
-    BoxOrPolygonPrediction,
     get_true_false_positives_confidences,
     group_boxes_or_polygons_by_label,
     iou_assignments,

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -1,30 +1,24 @@
 import sys
 from functools import wraps
-from typing import Dict, List, Tuple, TypeVar
+from typing import Dict, List, Tuple
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
-from shapely.geometry import Polygon
 
 from nucleus.annotation import BoxAnnotation, PolygonAnnotation
-from nucleus.prediction import BoxPrediction, PolygonPrediction
+
+from .custom_types import BoxOrPolygonAnnotation, BoxOrPolygonPrediction
+
+try:
+    from shapely.geometry import Polygon
+except ModuleNotFoundError:
+    from .shapely_not_installed import ShapelyNotInstalled
+
+    Polygon = ShapelyNotInstalled
+
 
 from .base import ScalarResult
 from .errors import PolygonAnnotationTypeError
-
-BoxOrPolygonPrediction = TypeVar(
-    "BoxOrPolygonPrediction", BoxPrediction, PolygonPrediction
-)
-BoxOrPolygonAnnotation = TypeVar(
-    "BoxOrPolygonAnnotation", BoxAnnotation, PolygonAnnotation
-)
-BoxOrPolygonAnnoOrPred = TypeVar(
-    "BoxOrPolygonAnnoOrPred",
-    BoxAnnotation,
-    PolygonAnnotation,
-    BoxPrediction,
-    PolygonPrediction,
-)
 
 
 def polygon_annotation_to_shape(

--- a/nucleus/metrics/shapely_not_installed.py
+++ b/nucleus/metrics/shapely_not_installed.py
@@ -1,0 +1,28 @@
+import sys
+
+
+class ShapelyNotInstalled:
+    def __init__(self, *args, **kwargs):
+        self.raise_error_msg()
+
+    def __getattr__(self, item):
+        self.raise_error_msg()
+
+    def raise_error_msg(self):
+        """Object to make sure we only raise errors if actually trying to use shapely"""
+        if sys.platform.startswith("darwin"):
+            platform_specific_msg = (
+                "Depending on Python environment used GEOS might need to be installed via "
+                "`brew install geos`."
+            )
+        elif sys.platform.startswith("linux"):
+            platform_specific_msg = (
+                "Depending on Python environment used GEOS might need to be installed via "
+                "system package `libgeos-dev`."
+            )
+        else:
+            platform_specific_msg = "GEOS package will need to be installed see (https://trac.osgeo.org/geos/)"
+        raise ModuleNotFoundError(
+            f"Module 'shapely' not found. Install optionally with `scale-nucleus[shapely]` or when developing "
+            f"`poetry install -E shapely`. {platform_specific_msg}"
+        )

--- a/tests/metrics/__init__.py
+++ b/tests/metrics/__init__.py
@@ -1,0 +1,9 @@
+import pytest
+
+try:
+    import shapely
+except ModuleNotFoundError:
+    pytest.skip(
+        "Shapely not installed, skipping (install with poetry install -E shapely)",
+        allow_module_level=True,
+    )

--- a/tests/metrics/test_geometry.py
+++ b/tests/metrics/test_geometry.py
@@ -1,6 +1,13 @@
 import numpy as np
 import pytest
-from shapely.geometry import LineString, Polygon
+
+try:
+    from shapely.geometry import LineString, Polygon
+except ModuleNotFoundError:
+    pytest.skip(
+        "Shapely not installed, skipping (install with poetry install -E shapely)",
+        allow_module_level=True,
+    )
 
 RECTANGLE1 = Polygon(
     [


### PR DESCRIPTION
This adds a bunch of import guards that make sure not installing shapely doesn't error out. 

The tests now run without shapely.