### PR TITLE
add check for duplicate ref_id, ann_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.8](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.10.8) - 2022-05-10
+
+### Fixed
+- Add checks for duplicate (`reference_id`, `annotation_id`) when uploading Annotations or Predictions
+
+
 ## [0.10.7](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.10.7) - 2022-05-09
 
 ### Fixed

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -212,11 +212,13 @@ class AnnotationUploader:
     @staticmethod
     def check_for_duplicate_ids(annotations: Iterable[Annotation]):
         """Do not allow annotations to have the same (annotation_id, reference_id) tuple"""
-        tuple_ids = [(ann.reference_id, ann.annotation_id) for ann in annotations if hasattr(ann, 'annotation_id')]
+        tuple_ids = [
+            (ann.reference_id, ann.annotation_id)
+            for ann in annotations
+            if hasattr(ann, "annotation_id")
+        ]
         tuple_count = Counter(tuple_ids)
-        duplicates = {
-            key for key, value in tuple_count.items() if value > 1
-        }
+        duplicates = {key for key, value in tuple_count.items() if value > 1}
         if len(duplicates) > 0:
             raise ValueError(
                 f"Duplicate annotations with the same (reference_id, annotation_id) properties found.\n"
@@ -224,6 +226,7 @@ class AnnotationUploader:
                 f"To fix this, avoid duplicate annotations, or specify a different annotation_id attribute "
                 f"for the failing items."
             )
+
 
 class PredictionUploader(AnnotationUploader):
     def __init__(

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -215,8 +215,7 @@ class AnnotationUploader:
 
         # some annotations like CategoryAnnotation do not have annotation_id attribute, and as such, we allow duplicates
         tuple_ids = [
-            # type: ignore
-            (ann.reference_id, ann.annotation_id)
+            (ann.reference_id, ann.annotation_id)  # type: ignore
             for ann in annotations
             if hasattr(ann, "annotation_id")
         ]

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -212,7 +212,10 @@ class AnnotationUploader:
     @staticmethod
     def check_for_duplicate_ids(annotations: Iterable[Annotation]):
         """Do not allow annotations to have the same (annotation_id, reference_id) tuple"""
+
+        # some annotations like CategoryAnnotation do not have annotation_id attribute, and as such, we allow duplicates
         tuple_ids = [
+            # type: ignore
             (ann.reference_id, ann.annotation_id)
             for ann in annotations
             if hasattr(ann, "annotation_id")

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -9,7 +9,7 @@ from nucleus.async_utils import (
     make_many_form_data_requests_concurrently,
 )
 from nucleus.constants import MASK_TYPE, SERIALIZED_REQUEST_KEY
-from nucleus.errors import DuplicateIDsError
+from nucleus.errors import DuplicateIDError
 from nucleus.payload_constructor import (
     construct_annotation_payload,
     construct_segmentation_payload,
@@ -223,7 +223,7 @@ class AnnotationUploader:
         tuple_count = Counter(tuple_ids)
         duplicates = {key for key, value in tuple_count.items() if value > 1}
         if len(duplicates) > 0:
-            raise DuplicateIDsError(
+            raise DuplicateIDError(
                 f"Duplicate annotations with the same (reference_id, annotation_id) properties found.\n"
                 f"Duplicates: {duplicates}\n"
                 f"To fix this, avoid duplicate annotations, or specify a different annotation_id attribute "

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence
 
 from nucleus.annotation import Annotation, SegmentationAnnotation
@@ -208,6 +209,21 @@ class AnnotationUploader:
 
         return fn
 
+    @staticmethod
+    def check_for_duplicate_ids(annotations: Iterable[Annotation]):
+        """Do not allow annotations to have the same (annotation_id, reference_id) tuple"""
+        tuple_ids = [(ann.reference_id, ann.annotation_id) for ann in annotations if hasattr(ann, 'annotation_id')]
+        tuple_count = Counter(tuple_ids)
+        duplicates = {
+            key for key, value in tuple_count.items() if value > 1
+        }
+        if len(duplicates) > 0:
+            raise ValueError(
+                f"Duplicate annotations with the same (reference_id, annotation_id) properties found.\n"
+                f"Duplicates: {duplicates}\n"
+                f"To fix this, avoid duplicate annotations, or specify a different annotation_id attribute "
+                f"for the failing items."
+            )
 
 class PredictionUploader(AnnotationUploader):
     def __init__(

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -9,6 +9,7 @@ from nucleus.async_utils import (
     make_many_form_data_requests_concurrently,
 )
 from nucleus.constants import MASK_TYPE, SERIALIZED_REQUEST_KEY
+from nucleus.errors import DuplicateIDsError
 from nucleus.payload_constructor import (
     construct_annotation_payload,
     construct_segmentation_payload,
@@ -222,7 +223,7 @@ class AnnotationUploader:
         tuple_count = Counter(tuple_ids)
         duplicates = {key for key, value in tuple_count.items() if value > 1}
         if len(duplicates) > 0:
-            raise ValueError(
+            raise DuplicateIDsError(
                 f"Duplicate annotations with the same (reference_id, annotation_id) properties found.\n"
                 f"Duplicates: {duplicates}\n"
                 f"To fix this, avoid duplicate annotations, or specify a different annotation_id attribute "

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -72,3 +72,9 @@ class NoAPIKey(Exception):
     ):
         self.message = message
         super().__init__(self.message)
+
+
+class DuplicateIDsError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -74,7 +74,7 @@ class NoAPIKey(Exception):
         super().__init__(self.message)
 
 
-class DuplicateIDsError(Exception):
+class DuplicateIDError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)

--- a/nucleus/model_run.py
+++ b/nucleus/model_run.py
@@ -154,6 +154,11 @@ class ModelRun:
             "predictions_ignored": int,
         }
         """
+        uploader = PredictionUploader(
+            model_run_id=self.model_run_id, client=self._client
+        )
+        uploader.check_for_duplicate_ids(annotations)
+
         if asynchronous:
             check_all_mask_paths_remote(annotations)
 
@@ -165,9 +170,7 @@ class ModelRun:
                 route=f"modelRun/{self.model_run_id}/predict?async=1",
             )
             return AsyncJob.from_json(response, self._client)
-        uploader = PredictionUploader(
-            model_run_id=self.model_run_id, client=self._client
-        )
+
         return uploader.upload(
             annotations=annotations,
             update=update,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.10.7"
+version = "0.10.8"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -9,12 +9,11 @@ from nucleus import (
     KeypointsAnnotation,
     LineAnnotation,
     MultiCategoryAnnotation,
-    Point,
     PolygonAnnotation,
-    Segment,
     SegmentationAnnotation,
 )
 from nucleus.constants import ERROR_PAYLOAD
+from nucleus.errors import DuplicateIDsError
 from nucleus.job import AsyncJob, JobError
 
 from .helpers import (
@@ -818,5 +817,5 @@ def test_box_gt_upload_embedding_async(CLIENT, dataset):
 def test_annotation_duplicate_ids_fail(dataset):
     box_ann = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
     annotations = [box_ann, box_ann]
-    with pytest.raises(ValueError):
+    with pytest.raises(DuplicateIDsError):
         dataset.annotate(annotations=annotations)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -813,3 +813,10 @@ def test_box_gt_upload_embedding_async(CLIENT, dataset):
     status = job.status()
     assert status["job_id"] == job.job_id
     assert status["status"] == "Running"
+
+
+def test_annotation_duplicate_ids_fail(dataset):
+    box_ann = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
+    annotations = [box_ann, box_ann]
+    with pytest.raises(ValueError):
+         dataset.annotate(annotations=[annotations])

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -9,7 +9,9 @@ from nucleus import (
     KeypointsAnnotation,
     LineAnnotation,
     MultiCategoryAnnotation,
+    Point,
     PolygonAnnotation,
+    Segment,
     SegmentationAnnotation,
 )
 from nucleus.constants import ERROR_PAYLOAD

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -819,4 +819,4 @@ def test_annotation_duplicate_ids_fail(dataset):
     box_ann = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
     annotations = [box_ann, box_ann]
     with pytest.raises(ValueError):
-        dataset.annotate(annotations=[annotations])
+        dataset.annotate(annotations=annotations)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -819,4 +819,4 @@ def test_annotation_duplicate_ids_fail(dataset):
     box_ann = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
     annotations = [box_ann, box_ann]
     with pytest.raises(ValueError):
-         dataset.annotate(annotations=[annotations])
+        dataset.annotate(annotations=[annotations])

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -13,7 +13,7 @@ from nucleus import (
     SegmentationAnnotation,
 )
 from nucleus.constants import ERROR_PAYLOAD
-from nucleus.errors import DuplicateIDsError
+from nucleus.errors import DuplicateIDError
 from nucleus.job import AsyncJob, JobError
 
 from .helpers import (
@@ -817,5 +817,5 @@ def test_box_gt_upload_embedding_async(CLIENT, dataset):
 def test_annotation_duplicate_ids_fail(dataset):
     box_ann = BoxAnnotation(**TEST_BOX_ANNOTATIONS[0])
     annotations = [box_ann, box_ann]
-    with pytest.raises(DuplicateIDsError):
+    with pytest.raises(DuplicateIDError):
         dataset.annotate(annotations=annotations)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -313,6 +313,7 @@ def test_dataset_append_async_with_local_path(dataset: Dataset):
     with pytest.raises(ValueError):
         dataset.append(ds_items, asynchronous=True)
 
+
 # TODO(Jean): Fix and remove skip, this is a flaky test
 @pytest.mark.skip(reason="Flaky test")
 def test_dataset_append_async_with_1_bad_url(dataset: Dataset):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -313,8 +313,8 @@ def test_dataset_append_async_with_local_path(dataset: Dataset):
     with pytest.raises(ValueError):
         dataset.append(ds_items, asynchronous=True)
 
-
-@pytest.mark.integration
+# TODO(Jean): Fix and remove skip, this is a flaky test
+@pytest.mark.skip(reason="Flaky test")
 def test_dataset_append_async_with_1_bad_url(dataset: Dataset):
     ds_items = make_dataset_items()
     ds_items[0].image_location = "https://looks.ok.but.is.not.accessible"

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import pytest
@@ -10,9 +9,7 @@ from nucleus import (
     KeypointsPrediction,
     LinePrediction,
     ModelRun,
-    Point,
     PolygonPrediction,
-    Segment,
     SegmentationPrediction,
 )
 from nucleus.constants import ERROR_PAYLOAD
@@ -724,3 +721,14 @@ def test_box_pred_upload_embedding_async(CLIENT, model_run):
     status = job.status()
     assert status["job_id"] == job.job_id
     assert status["status"] == "Running"
+
+
+def test_prediction_duplicate_ids_fail(dataset, model_run):
+    box_pred = BoxPrediction(**TEST_BOX_PREDICTIONS_EMBEDDINGS[0])
+    predictions = [box_pred, box_pred]
+
+    with pytest.raises(ValueError):
+        dataset.upload_predictions(annotations=predictions)
+
+    with pytest.raises(ValueError):
+        model_run.predict(annotations=predictions)

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -9,7 +9,9 @@ from nucleus import (
     KeypointsPrediction,
     LinePrediction,
     ModelRun,
+    Point,
     PolygonPrediction,
+    Segment,
     SegmentationPrediction,
 )
 from nucleus.constants import ERROR_PAYLOAD

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -13,6 +13,7 @@ from nucleus import (
     SegmentationPrediction,
 )
 from nucleus.constants import ERROR_PAYLOAD
+from nucleus.errors import DuplicateIDsError
 from nucleus.job import AsyncJob, JobError
 
 from .helpers import (
@@ -727,8 +728,8 @@ def test_prediction_duplicate_ids_fail(dataset, model, model_run):
     box_pred = BoxPrediction(**TEST_BOX_PREDICTIONS_EMBEDDINGS[0])
     predictions = [box_pred, box_pred]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DuplicateIDsError):
         dataset.upload_predictions(model, predictions=predictions)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DuplicateIDsError):
         model_run.predict(annotations=predictions)

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -723,12 +723,12 @@ def test_box_pred_upload_embedding_async(CLIENT, model_run):
     assert status["status"] == "Running"
 
 
-def test_prediction_duplicate_ids_fail(dataset, model_run):
+def test_prediction_duplicate_ids_fail(dataset, model, model_run):
     box_pred = BoxPrediction(**TEST_BOX_PREDICTIONS_EMBEDDINGS[0])
     predictions = [box_pred, box_pred]
 
     with pytest.raises(ValueError):
-        dataset.upload_predictions(annotations=predictions)
+        dataset.upload_predictions(model, predictions=predictions)
 
     with pytest.raises(ValueError):
         model_run.predict(annotations=predictions)

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -13,7 +13,7 @@ from nucleus import (
     SegmentationPrediction,
 )
 from nucleus.constants import ERROR_PAYLOAD
-from nucleus.errors import DuplicateIDsError
+from nucleus.errors import DuplicateIDError
 from nucleus.job import AsyncJob, JobError
 
 from .helpers import (
@@ -728,8 +728,8 @@ def test_prediction_duplicate_ids_fail(dataset, model, model_run):
     box_pred = BoxPrediction(**TEST_BOX_PREDICTIONS_EMBEDDINGS[0])
     predictions = [box_pred, box_pred]
 
-    with pytest.raises(DuplicateIDsError):
+    with pytest.raises(DuplicateIDError):
         dataset.upload_predictions(model, predictions=predictions)
 
-    with pytest.raises(DuplicateIDsError):
+    with pytest.raises(DuplicateIDError):
         model_run.predict(annotations=predictions)


### PR DESCRIPTION
Provide check for duplicate (`ref_id`, `ann_id`) on annotation and predictions upload.