### PR TITLE
Remove the log statement warning of an un-implemented standard function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.12.1) - 2022-06-02
+
+### Added
+
+- Suppress warning statement when un-implemented standard configs found
+
 ## [0.12.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.12.0) - 2022-05-27
 
 ### Added

--- a/nucleus/validate/eval_functions/available_eval_functions.py
+++ b/nucleus/validate/eval_functions/available_eval_functions.py
@@ -1,7 +1,6 @@
 import itertools
 from typing import Callable, Dict, List, Optional, Union
 
-from nucleus.logger import logger
 from nucleus.validate.eval_functions.base_eval_function import (
     EvalFunctionConfig,
 )
@@ -1148,13 +1147,6 @@ class StandardEvalFunction(EvalFunctionConfig):
     """Class for standard Model CI eval functions that have not been added as attributes on
     AvailableEvalFunctions yet.
     """
-
-    def __init__(self, eval_function_entry: EvalFunctionEntry):
-        logger.warning(
-            "Standard function %s not implemented as an attribute on AvailableEvalFunctions",
-            eval_function_entry.name,
-        )
-        super().__init__(eval_function_entry)
 
     @classmethod
     def expected_name(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.12.0"
+version = "0.12.1"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]
@@ -53,7 +53,7 @@ scale-launch = { git = "https://github.com/scaleapi/launch-python-client.git", p
 
 [tool.poetry.dev-dependencies]
 pytest = [
-  { version = ">=6.2.3", python = ">=3.6.2,<3.7" }, 
+  { version = ">=6.2.3", python = ">=3.6.2,<3.7" },
   { version = ">=7.1.1", python = ">=3.7,<4.0" }
 ]
 pylint = "^2.7.4"


### PR DESCRIPTION
This removes the annoying warning statement when more evaluations are implemented than are with the local version 🙂 