### PR TITLE
Open up dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.2) - 2022-06-08
+
+### Fixed
+
+- Open up requirements for easier installation in more environments. Add more optional installs under `metrics`
+ 
 ## [0.13.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.1) - 2022-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.1) - 2022-06-08
+
+### Fixed
+
+- Make installation of scale-launch optional
+
 ## [0.13.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.0) - 2022-06-08
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,7 @@ name = "aiobotocore"
 version = "2.1.2"
 description = "Async client for aws services using botocore and aiohttp"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -66,7 +66,7 @@ name = "aioitertools"
 version = "0.10.0"
 description = "itertools and builtins for AsyncIO and mixed iterables"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -298,7 +298,7 @@ name = "botocore"
 version = "1.23.24"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
-optional = false
+optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
@@ -561,7 +561,7 @@ name = "fsspec"
 version = "2022.1.0"
 description = "File-system specification"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -797,7 +797,7 @@ name = "jmespath"
 version = "0.10.0"
 description = "JSON Matching Expressions"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -1631,7 +1631,7 @@ name = "s3fs"
 version = "2022.1.0"
 description = "Convenient Filesystem interface over S3"
 category = "main"
-optional = false
+optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
@@ -2136,12 +2136,12 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-metrics = ["Shapely", "rasterio"]
+metrics = ["Shapely", "rasterio", "s3fs"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "48513a267dde6f7e0d1f16bfa3822e280efb5f27e2ebfc85c601e04e9eaa2184"
+content-hash = "5e4644e04e1f2c1ce893240396be5ead7216f054432bc6768825f8d7522e1075"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.13.0"
+version = "0.13.1"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]
@@ -49,7 +49,7 @@ Shapely = { version = ">=1.8.0", optional = true }
 rasterio = { version = "^1.2.10", optional = true }
 Pillow = ">=7.1.2"
 s3fs = ">=2022.1.0"
-scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" }
+scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" , optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = [
@@ -76,6 +76,7 @@ nu = "cli.nu:nu"
 
 [tool.poetry.extras]
 metrics = ["Shapely", "rasterio"]
+launch = ["scale-launch"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.13.1"
+version = "0.13.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]
@@ -48,8 +48,8 @@ scikit-learn = ">=0.24.0"
 Shapely = { version = ">=1.8.0", optional = true }
 rasterio = { version = "^1.2.10", optional = true }
 Pillow = ">=7.1.2"
-s3fs = ">=2022.1.0"
-scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" , optional = true}
+s3fs = {version = ">=2021.9.0", optional = true }
+scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" }
 
 [tool.poetry.dev-dependencies]
 pytest = [
@@ -75,8 +75,7 @@ pytest-xdist = "^2.5.0"
 nu = "cli.nu:nu"
 
 [tool.poetry.extras]
-metrics = ["Shapely", "rasterio"]
-launch = ["scale-launch"]
+metrics = ["Shapely", "rasterio", "s3fs"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This opens up dependencies and limits what we install when we don't install `metrics`. This makes installation possible in COLAB. We were erroring out before.