### PR TITLE
Make scale-launch optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.3) - 2022-06-08
+
+### Fixed
+- Make installation of scale-launch optional (again!).
+
 ## [0.13.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.2) - 2022-06-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.13.2"
+version = "0.13.3"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]
@@ -49,7 +49,7 @@ Shapely = { version = ">=1.8.0", optional = true }
 rasterio = { version = "^1.2.10", optional = true }
 Pillow = ">=7.1.2"
 s3fs = {version = ">=2021.9.0", optional = true }
-scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" }
+scale-launch = { version = ">=0.1.0", python = ">=3.7,<4.0" , optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = [
@@ -76,6 +76,7 @@ nu = "cli.nu:nu"
 
 [tool.poetry.extras]
 metrics = ["Shapely", "rasterio", "s3fs"]
+launch = ["scale-launch"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
`scale-launch` pinned dependencies cause problems with Google COLAB, we'll make launch optional for now until these dependency conflicts have been fixed.

To install `launch` you have to install `scale-nucleus[launch]` now.