### PR TITLE
Add import guards for new extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,17 @@ workflows:
     jobs:
       - build_test:
           context: Nucleus
+  installation_matrix:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test_installation:
+          context: Nucleus
   build_test_publish:
     jobs:
       - build_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,21 @@ jobs:
     steps:
       - checkout # checkout source code to working directory
       - run:
-          name: Install Environment Dependencies
+          name: Install Basic Environment Dependencies
           command: | # install dependencies
             apt-get update
             apt-get -y install curl libgeos-dev
             pip install --upgrade pip
             pip install poetry
-            poetry install -E metrics
-
+            poetry install -E metric
+      - run:
+          name: Test Imports (extras need to be guarded!)
+          command: | # Make sure that importing works without extras installed
+            poetry run python -c 'import nucleus'
+      - run:
+          name: Install Extra Dependencies
+          command: | # install dependencies
+            poetry install -E metrics -E launch
       - run:
           name: Black Formatting Check # Only validation, without re-formatting
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             apt-get -y install curl libgeos-dev
             pip install --upgrade pip
             pip install poetry
-            poetry install -E metric
+            poetry install
       - run:
           name: Test Imports (extras need to be guarded!)
           command: | # Make sure that importing works without extras installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,17 +117,6 @@ workflows:
     jobs:
       - build_test:
           context: Nucleus
-  installation_matrix:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - test_installation:
-          context: Nucleus
   build_test_publish:
     jobs:
       - build_test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.3) - 2022-06-08
+## [0.13.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.4) - 2022-06-09
+
+### Fixed
+- Guard against extras imports 
+
+## [0.13.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.3) - 2022-06-09
 
 ### Fixed
 - Make installation of scale-launch optional (again!).

--- a/nucleus/metrics/segmentation_metrics.py
+++ b/nucleus/metrics/segmentation_metrics.py
@@ -1,10 +1,17 @@
 import abc
 from typing import List, Optional, Union
 
-import fsspec
 import numpy as np
 from PIL import Image
-from s3fs import S3FileSystem
+
+try:
+    import fsspec
+    from s3fs import S3FileSystem
+except ModuleNotFoundError:
+    from ..package_not_installed import PackageNotInstalled
+
+    S3FileSystem = PackageNotInstalled
+    fsspec = PackageNotInstalled
 
 from nucleus.annotation import AnnotationList, SegmentationAnnotation
 from nucleus.metrics.base import MetricResult

--- a/nucleus/metrics/segmentation_to_poly_metrics.py
+++ b/nucleus/metrics/segmentation_to_poly_metrics.py
@@ -1,10 +1,8 @@
 import abc
 from typing import List, Optional, Union
 
-import fsspec
 import numpy as np
 from PIL import Image
-from s3fs import S3FileSystem
 
 from nucleus.annotation import AnnotationList
 from nucleus.metrics.base import MetricResult
@@ -14,6 +12,15 @@ from nucleus.metrics.segmentation_utils import (
     transform_poly_codes_to_poly_preds,
 )
 from nucleus.prediction import PredictionList
+
+try:
+    import fsspec
+    from s3fs import S3FileSystem
+except ModuleNotFoundError:
+    from ..package_not_installed import PackageNotInstalled
+
+    S3FileSystem = PackageNotInstalled
+    fsspec = PackageNotInstalled
 
 from .base import Metric, ScalarResult
 from .polygon_metrics import (

--- a/poetry.lock
+++ b/poetry.lock
@@ -392,7 +392,7 @@ name = "cloudpickle"
 version = "2.1.0"
 description = "Extended pickling support for Python objects"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -449,7 +449,7 @@ name = "dataclasses-json"
 version = "0.5.7"
 description = "Easily serialize dataclasses to and from JSON"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -984,7 +984,7 @@ name = "marshmallow"
 version = "3.16.0"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1001,7 +1001,7 @@ name = "marshmallow-enum"
 version = "1.5.1"
 description = "Enum field for Marshmallow"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1648,7 +1648,7 @@ name = "scale-launch"
 version = "0.1.0"
 description = "The official Python client library for Launch, the Data Platform for AI"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
@@ -2025,7 +2025,7 @@ name = "typing-inspect"
 version = "0.7.1"
 description = "Runtime inspection utilities for typing module."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -2136,12 +2136,13 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
+launch = ["scale-launch"]
 metrics = ["Shapely", "rasterio", "s3fs"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "5e4644e04e1f2c1ce893240396be5ead7216f054432bc6768825f8d7522e1075"
+content-hash = "9f7ea5db973dcec81f68f9db5b54441aaae45533d3ca3953af1a530b67172c98"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.13.3"
+version = "0.13.4"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
This PR adds import guards for new extras as well as creating a new step in the tests that make sure that basic nucleus functionality is not affected by not installing the extras.