### PR TITLE
Add tags to Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.12.3) - 2022-06-14
+
+### Added
+
+- Allow creation of model tags on new and existing models, eg:
+```python
+client = nucleus.NucleusClient(API_KEY)
+
+# on model creation
+model = client.create_model(
+  name="foo_model",
+  reference_id="foo-model-ref",
+  tags=["some tag"]
+)
+
+# on existing models
+existing_model = client.models[0]
+existing_model.tag(['some tag'])
+```
+
 ## [0.12.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.12.4) - 2022-06-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Allow creation of model tags on new and existing models, eg:
+- Allow creation/deletion of model tags on new and existing models, eg:
 ```python
 # on model creation
 model = client.create_model(name="foo_model", reference_id="foo-model-ref", tags=["some tag"])
 
 # on existing models
 existing_model = client.models[0]
-existing_model.add_tag(['some tag'])
+existing_model.add_tag(['tag a', 'tag b'])
+
+# remove tag
+existing_model.remove_tag(['tag a'])
 ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ model = client.create_model(name="foo_model", reference_id="foo-model-ref", tags
 
 # on existing models
 existing_model = client.models[0]
-existing_model.add_tag(['tag a', 'tag b'])
+existing_model.add_tags(['tag a', 'tag b'])
 
 # remove tag
-existing_model.remove_tag(['tag a'])
+existing_model.remove_tags(['tag a'])
 ```
 
 ## [0.13.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.4) - 2022-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ model = client.create_model(name="foo_model", reference_id="foo-model-ref", tags
 
 # on existing models
 existing_model = client.models[0]
-existing_model.tag(['some tag'])
+existing_model.add_tag(['some tag'])
 ```
 
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -91,6 +91,7 @@ from .constants import (
     KEEP_HISTORY_KEY,
     MESSAGE_KEY,
     MODEL_RUN_ID_KEY,
+    MODEL_TAGS_KEY,
     NAME_KEY,
     NUCLEUS_ENDPOINT,
     PREDICTIONS_IGNORED_KEY,
@@ -218,7 +219,7 @@ class NucleusClient:
                 reference_id=model["ref_id"],
                 metadata=model["metadata"] or None,
                 client=self,
-                tags=model.get("tags", []),
+                tags=model.get(MODEL_TAGS_KEY, []),
             )
             for model in model_objects["models"]
         ]

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -218,6 +218,7 @@ class NucleusClient:
                 reference_id=model["ref_id"],
                 metadata=model["metadata"] or None,
                 client=self,
+                tags=model.get("tags", []),
             )
             for model in model_objects["models"]
         ]

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -484,6 +484,7 @@ class NucleusClient:
         reference_id: str,
         metadata: Optional[Dict] = None,
         bundle_name: Optional[str] = None,
+        tags: Optional[List[str]] = None
     ) -> Model:
         """Adds a :class:`Model` to Nucleus.
 
@@ -495,13 +496,15 @@ class NucleusClient:
             metadata: An arbitrary dictionary of additional data about this model
               that can be stored and retrieved. For example, you can store information
               about the hyperparameters used in training this model.
+            bundle_name: Optional name of bundle attached to this model
+            tags: Optional list of tags to attach to this model
 
         Returns:
             :class:`Model`: The newly created model as an object.
         """
         response = self.make_request(
             construct_model_creation_payload(
-                name, reference_id, metadata, bundle_name
+                name, reference_id, metadata, bundle_name, tags
             ),
             "models/add",
         )

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -484,7 +484,7 @@ class NucleusClient:
         reference_id: str,
         metadata: Optional[Dict] = None,
         bundle_name: Optional[str] = None,
-        tags: Optional[List[str]] = None
+        tags: Optional[List[str]] = None,
     ) -> Model:
         """Adds a :class:`Model` to Nucleus.
 
@@ -519,6 +519,7 @@ class NucleusClient:
             metadata=metadata,
             bundle_name=bundle_name,
             client=self,
+            tags=tags,
         )
 
     def create_launch_model(

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -90,6 +90,7 @@ MAX_PAYLOAD_SIZE = 0x1FFFFFE8  # Set to max string size since we currently conve
 MESSAGE_KEY = "message"
 METADATA_KEY = "metadata"
 MODEL_BUNDLE_NAME_KEY = "bundle_name"
+MODEL_TAGS_KEY = "tags"
 MODEL_ID_KEY = "model_id"
 MODEL_RUN_ID_KEY = "model_run_id"
 NAME_KEY = "name"

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -222,57 +222,48 @@ class Model:
 
         return response
 
-    def add_tag(self, tags: Union[str, List[str]]):
-        """Tag the model with a custom tag name. ::
+    def add_tags(self, tags: List[str]):
+        """Tag the model with custom tag names. ::
 
             import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             model = client.list_models()[0]
 
-            model.add_tag("tag_x")
-            model.add_tag(["tag_A", "tag_B"])
+            model.add_tags(["tag_A", "tag_B"])
 
         Args:
-            tags: single tag name, or list of tag names
-
+            tags: list of tag names
         """
-
-        payload = {MODEL_TAGS_KEY: [tags] if isinstance(tags, str) else tags}
         response = self._client.make_request(
-            payload,
+            {MODEL_TAGS_KEY: tags},
             f"model/{self.id}/tag",
             requests_command=requests.post,
         )
 
         if response.get("msg", False):
-            self.tags.extend([tags] if isinstance(tags, str) else tags)
+            self.tags.extend(tags)
 
         return response
 
-    def remove_tag(self, tags: Union[str, List[str]]):
-        """Tag the model with a custom tag name. ::
+    def remove_tags(self, tags: List[str]):
+        """Remove tag(s) from the model. ::
 
             import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             model = client.list_models()[0]
 
-            model.add_tag("tag_x")
-            model.add_tag(["tag_A", "tag_B"])
+            model.remove_tags(["tag_x"])
 
         Args:
-            tags: single tag name, or list of tag names
-
+            tags: list of tag names to remove
         """
-
-        payload = {MODEL_TAGS_KEY: [tags] if isinstance(tags, str) else tags}
         response = self._client.make_request(
-            payload,
+            {MODEL_TAGS_KEY: tags},
             f"model/{self.id}/tag",
             requests_command=requests.delete,
         )
 
         if response.get("msg", False):
-            rm_tags = [tags] if isinstance(tags, str) else tags
-            self.tags = list(filter(lambda t: t not in rm_tags, self.tags))
+            self.tags = list(filter(lambda t: t not in tags, self.tags))
 
         return response

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -100,14 +100,14 @@ class Model:
         metadata,
         client,
         bundle_name=None,
-        tags=None,
+        tags: Optional[List[str]] = None,
     ):
         self.id = model_id
         self.name = name
         self.reference_id = reference_id
         self.metadata = metadata
         self.bundle_name = bundle_name
-        self._tags = tags
+        self.tags = tags
         self._client = client
 
     def __repr__(self):
@@ -135,10 +135,6 @@ class Model:
             metadata=payload["metadata"] or None,
             client=client,
         )
-
-    @property
-    def tags(self):
-        return self._tags
 
     def create_run(
         self,
@@ -247,5 +243,8 @@ class Model:
             f"model/{self.id}/tag",
             requests_command=requests.post,
         )
+
+        if response.get("msg", False):
+            self.tags.extend([tags] if isinstance(tags, str) else tags)
 
         return response

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -222,15 +222,15 @@ class Model:
 
         return response
 
-    def tag(self, tags: Union[str, List[str]]):
+    def add_tag(self, tags: Union[str, List[str]]):
         """Tag the model with a custom tag name. ::
 
             import nucleus
             client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
             model = client.list_models()[0]
 
-            model.tag("tag_x")
-            model.tag(["tag_A", "tag_B"])
+            model.add_tag("tag_x")
+            model.add_tag(["tag_A", "tag_B"])
 
         Args:
             tags: single tag name, or list of tag names

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Union
 
 import requests
 
-from .constants import METADATA_KEY, NAME_KEY, REFERENCE_ID_KEY
+from .constants import METADATA_KEY, MODEL_TAGS_KEY, NAME_KEY, REFERENCE_ID_KEY
 from .dataset import Dataset
 from .job import AsyncJob
 from .model_run import ModelRun
@@ -237,7 +237,7 @@ class Model:
 
         """
 
-        payload = {"tags": [tags] if isinstance(tags, str) else tags}
+        payload = {MODEL_TAGS_KEY: [tags] if isinstance(tags, str) else tags}
         response = self._client.make_request(
             payload,
             f"model/{self.id}/tag",

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -93,13 +93,14 @@ class Model:
     """
 
     def __init__(
-        self, model_id, name, reference_id, metadata, client, bundle_name=None
+        self, model_id, name, reference_id, metadata, client, bundle_name=None, tags=None,
     ):
         self.id = model_id
         self.name = name
         self.reference_id = reference_id
         self.metadata = metadata
         self.bundle_name = bundle_name
+        self._tags = tags
         self._client = client
 
     def __repr__(self):
@@ -127,6 +128,10 @@ class Model:
             metadata=payload["metadata"] or None,
             client=client,
         )
+
+    @property
+    def tags(self):
+        return self._tags
 
     def create_run(
         self,

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -248,3 +248,31 @@ class Model:
             self.tags.extend([tags] if isinstance(tags, str) else tags)
 
         return response
+
+    def remove_tag(self, tags: Union[str, List[str]]):
+        """Tag the model with a custom tag name. ::
+
+            import nucleus
+            client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
+            model = client.list_models()[0]
+
+            model.add_tag("tag_x")
+            model.add_tag(["tag_A", "tag_B"])
+
+        Args:
+            tags: single tag name, or list of tag names
+
+        """
+
+        payload = {MODEL_TAGS_KEY: [tags] if isinstance(tags, str) else tags}
+        response = self._client.make_request(
+            payload,
+            f"model/{self.id}/tag",
+            requests_command=requests.delete,
+        )
+
+        if response.get("msg", False):
+            rm_tags = [tags] if isinstance(tags, str) else tags
+            self.tags = list(filter(lambda t: t not in rm_tags, self.tags))
+
+        return response

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -225,3 +225,27 @@ class Model:
         )
 
         return response
+
+    def tag(self, tags: Union[str, List[str]]):
+        """Tag the model with a custom tag name. ::
+
+            import nucleus
+            client = nucleus.NucleusClient("YOUR_SCALE_API_KEY")
+            model = client.list_models()[0]
+
+            model.tag("tag_x")
+            model.tag(["tag_A", "tag_B"])
+
+        Args:
+            tags: single tag name, or list of tag names
+
+        """
+
+        payload = {"tags": [tags] if isinstance(tags, str) else tags}
+        response = self._client.make_request(
+            payload,
+            f"model/{self.id}/tag",
+            requests_command=requests.post,
+        )
+
+        return response

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -100,14 +100,14 @@ class Model:
         metadata,
         client,
         bundle_name=None,
-        tags: Optional[List[str]] = None,
+        tags: List[str] = None,
     ):
         self.id = model_id
         self.name = name
         self.reference_id = reference_id
         self.metadata = metadata
         self.bundle_name = bundle_name
-        self.tags = tags
+        self.tags = tags if tags else []
         self._client = client
 
     def __repr__(self):

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -93,7 +93,14 @@ class Model:
     """
 
     def __init__(
-        self, model_id, name, reference_id, metadata, client, bundle_name=None, tags=None,
+        self,
+        model_id,
+        name,
+        reference_id,
+        metadata,
+        client,
+        bundle_name=None,
+        tags=None,
     ):
         self.id = model_id
         self.name = name

--- a/nucleus/payload_constructor.py
+++ b/nucleus/payload_constructor.py
@@ -17,6 +17,7 @@ from .constants import (
     METADATA_KEY,
     MODEL_BUNDLE_NAME_KEY,
     MODEL_ID_KEY,
+    MODEL_TAGS_KEY,
     NAME_KEY,
     REFERENCE_ID_KEY,
     SCENES_KEY,
@@ -127,6 +128,7 @@ def construct_model_creation_payload(
     reference_id: str,
     metadata: Optional[Dict],
     bundle_name: Optional[str],
+    tags: Optional[List[str]],
 ) -> dict:
     payload = {
         NAME_KEY: name,
@@ -136,6 +138,8 @@ def construct_model_creation_payload(
 
     if bundle_name:
         payload[MODEL_BUNDLE_NAME_KEY] = bundle_name
+    if tags:
+        payload[MODEL_TAGS_KEY] = tags
 
     return payload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.12.4"
+version = "0.13.0"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,16 +130,16 @@ def test_tag_model(CLIENT, dataset: Dataset):
         TEST_MODEL_NAME, model_reference, tags=["first_tag"]
     )
 
-    model.add_tag("single tag")
-    model.add_tag(["tag_a", "tag_b"])
+    model.add_tags(["single tag"])
+    model.add_tags(["tag_a", "tag_b"])
 
     backend_model = testing_model(model_reference)
     assert sorted(backend_model.tags) == sorted(
         ["first_tag", "single tag", "tag_a", "tag_b"]
     )
 
-    model.remove_tag("tag_a")
-    model.remove_tag(["first_tag", "tag_b"])
+    model.remove_tags(["tag_a"])
+    model.remove_tags(["first_tag", "tag_b"])
 
     backend_model = testing_model(model_reference)
     assert backend_model.tags == ["single tag"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -126,9 +126,10 @@ def test_tag_model(CLIENT, dataset: Dataset):
     model.tag("single tag")
     model.tags(["tag_a", "tag_b"])
 
-    model_from_backend = list(
+    models_from_backend = list(
         filter(lambda m: m.reference_id == model_reference, CLIENT.models)
-    )[0]
-    assert sorted(model_from_backend.tags) == sorted(
+    )
+    assert len(models_from_backend) == 1
+    assert sorted(models_from_backend[0].tags) == sorted(
         ["first_tag", "single tag", "tag_a", "tag_b"]
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,3 +115,20 @@ def test_new_model_endpoints(CLIENT, dataset: Dataset):
         model, predictions[0].reference_id, predictions[0].annotation_id
     )
     assert_box_prediction_matches_dict(prediction_loc, TEST_BOX_PREDICTIONS[0])
+
+
+def test_tag_model(CLIENT, dataset: Dataset):
+    model_reference = "model_" + str(time.time())
+    model = CLIENT.create_model(
+        TEST_MODEL_NAME, model_reference, tags=["first_tag"]
+    )
+
+    model.tag("single tag")
+    model.tags(["tag_a", "tag_b"])
+
+    model_from_backend = list(
+        filter(lambda m: m.reference_id == model_reference, CLIENT.models)
+    )[0]
+    assert sorted(model_from_backend.tags) == sorted(
+        ["first_tag", "single tag", "tag_a", "tag_b"]
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -143,3 +143,18 @@ def test_tag_model(CLIENT, dataset: Dataset):
 
     backend_model = testing_model(model_reference)
     assert backend_model.tags == ["single tag"]
+
+
+def test_remove_invalid_tag_from_model(CLIENT, dataset: Dataset):
+
+    model_reference = "model_" + str(time.time())
+    model = CLIENT.create_model(TEST_MODEL_NAME, model_reference)
+
+    model.add_tags(["single tag"])
+
+    response = model.remove_tags(["tag_a"])
+    assert "error" in response
+    assert (
+        response["error"]
+        == "Deleted 0 tags from model. Either the tag(s) did not exist, or you are not the owner of this model project."
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,6 +118,14 @@ def test_new_model_endpoints(CLIENT, dataset: Dataset):
 
 
 def test_tag_model(CLIENT, dataset: Dataset):
+
+    def testing_model(ref_id):
+        models_from_backend = list(
+            filter(lambda m: m.reference_id == ref_id, CLIENT.models)
+        )
+        assert len(models_from_backend) == 1
+        return models_from_backend[0]
+
     model_reference = "model_" + str(time.time())
     model = CLIENT.create_model(
         TEST_MODEL_NAME, model_reference, tags=["first_tag"]
@@ -126,10 +134,13 @@ def test_tag_model(CLIENT, dataset: Dataset):
     model.add_tag("single tag")
     model.add_tag(["tag_a", "tag_b"])
 
-    models_from_backend = list(
-        filter(lambda m: m.reference_id == model_reference, CLIENT.models)
-    )
-    assert len(models_from_backend) == 1
-    assert sorted(models_from_backend[0].tags) == sorted(
+    backend_model = testing_model(model_reference)
+    assert sorted(backend_model.tags) == sorted(
         ["first_tag", "single tag", "tag_a", "tag_b"]
     )
+
+    model.remove_tag("tag_a")
+    model.remove_tag(["first_tag", "tag_b"])
+
+    backend_model = testing_model(model_reference)
+    assert backend_model.tags == ["single tag"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,7 +118,6 @@ def test_new_model_endpoints(CLIENT, dataset: Dataset):
 
 
 def test_tag_model(CLIENT, dataset: Dataset):
-
     def testing_model(ref_id):
         models_from_backend = list(
             filter(lambda m: m.reference_id == ref_id, CLIENT.models)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -123,8 +123,8 @@ def test_tag_model(CLIENT, dataset: Dataset):
         TEST_MODEL_NAME, model_reference, tags=["first_tag"]
     )
 
-    model.tag("single tag")
-    model.tags(["tag_a", "tag_b"])
+    model.add_tag("single tag")
+    model.add_tag(["tag_a", "tag_b"])
 
     models_from_backend = list(
         filter(lambda m: m.reference_id == model_reference, CLIENT.models)


### PR DESCRIPTION
**note**: works on running the backend: https://github.com/scaleapi/scaleapi/pull/41353/files

Allow users to create tags on models

Example:


```python

# on existing models
m = client.models[0]
m.add_tag('some_tag')
m.add_tag(['a', 'b'])
print(m.tags)

# on model creation=
model = client.create_model(
    name="foo_model",
    reference_id="foo-model-ref",
    tags=["some tag"]
)
print(model.tags)

# delete

m.remove_tag(['a'])
```

Results can also be visualized on the models pages 