### PR TITLE
Throw error if index in skeleton is greater than number of keypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.4) - 2022-06-15
+
+### Fixed
+- Guard against invalid skeleton indexes in KeypointsAnnotation
+
 ## [0.13.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.13.4) - 2022-06-09
 
 ### Fixed

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -439,7 +439,7 @@ class KeypointsAnnotation(Annotation):
             label="face",
             keypoints=[Keypoint(100, 100), Keypoint(120, 120), Keypoint(visible=False), Keypoint(0, 0)],
             names=["point1", "point2", "point3", "point4"],
-            skeleton=[[0, 1], [1, 2], [1, 3], [2, 4]],
+            skeleton=[[0, 1], [1, 2], [1, 3], [2, 3]],
             reference_id="image_2",
             annotation_id="image_2_face_keypoints_1",
             metadata={"face_direction": "forward"},
@@ -486,11 +486,17 @@ class KeypointsAnnotation(Annotation):
                     )
                 seen.add(name)
 
+        max_segment_index = len(self.keypoints) - 1
         for segment in self.skeleton:
             if len(segment) != 2:
                 raise ValueError(
                     "The keypoints skeleton must contain a list of line segments with exactly 2 indices"
                 )
+            for index in segment:
+                if index > max_segment_index:
+                    raise ValueError(
+                        f"The skeleton index {index} is not a valid keypoint index"
+                    )
 
     @classmethod
     def from_json(cls, payload: dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.13.4"
+version = "0.13.5"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Make sure all the indexes in the skeleton are valid.

```
----> 1 keypoints = KeypointsAnnotation(
      2         label="face",
      3         keypoints=[Keypoint(100, 100), Keypoint(120, 120), Keypoint(visible=False), Keypoint(0, 0)],
      4         names=["point1", "point2", "point3", "point4"],
      5         skeleton=[[0, 1], [1, 2], [1, 3], [2, 4]],

~/Development/nucleus-python-client/nucleus/annotation.py in __init__(self, label, keypoints, names, skeleton, reference_id, annotation_id, metadata)

~/Development/nucleus-python-client/nucleus/annotation.py in __post_init__(self)
    495             for index in segment:
    496                 if index > max_segment_index:
--> 497                     raise ValueError(
    498                         f"The skeleton index {index} is not a valid keypoint index"
    499                     )

ValueError: The skeleton index 4 is not a valid keypoint index
```