### PR TITLE
Default delete_annotation ref_ids to an empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.6](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.6) - 2022-07-07
+
+### Fixed
+- `Dataset.delete_annotations` now defaults `reference_ids` to an empty list and `keep_history` to true
+
 ## [0.14.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.5) - 2022-07-05
 
 ### Fixed

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -852,7 +852,7 @@ class NucleusClient:
 
     @deprecated("Prefer calling Dataset.delete_annotations instead.")
     def delete_annotations(
-        self, dataset_id: str, reference_ids: list = None, keep_history=False
+        self, dataset_id: str, reference_ids: list = None, keep_history=True
     ) -> AsyncJob:
         dataset = self.get_dataset(dataset_id)
         return dataset.delete_annotations(reference_ids, keep_history)

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1219,7 +1219,7 @@ class Dataset:
 
         Parameters:
             reference_ids: List of user-defined reference IDs of the dataset items
-              from which to delete annotations.
+              from which to delete annotations. Defaults to an empty list.
             keep_history: Whether to preserve version history. If False, all
                 previous versions will be deleted along with the annotations. If
                 True, the version history (including deletion) wil persist.
@@ -1228,9 +1228,12 @@ class Dataset:
         Returns:
             :class:`AsyncJob`: Empty payload response.
         """
-        payload = {KEEP_HISTORY_KEY: keep_history}
-        if reference_ids:
-            payload[REFERENCE_IDS_KEY] = reference_ids
+        if reference_ids is None:
+            reference_ids = []
+        payload = {
+            KEEP_HISTORY_KEY: keep_history,
+            REFERENCE_IDS_KEY: reference_ids,
+        }
         response = self._client.make_request(
             payload,
             f"annotation/{self.id}",

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1213,7 +1213,7 @@ class Dataset:
         return api_payload  # type: ignore
 
     def delete_annotations(
-        self, reference_ids: list = None, keep_history=False
+        self, reference_ids: list = None, keep_history=True
     ) -> AsyncJob:
         """Deletes all annotations associated with the specified item reference IDs.
 
@@ -1223,7 +1223,7 @@ class Dataset:
             keep_history: Whether to preserve version history. If False, all
                 previous versions will be deleted along with the annotations. If
                 True, the version history (including deletion) wil persist.
-                Default is False.
+                Default is True.
 
         Returns:
             :class:`AsyncJob`: Empty payload response.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.5"
+version = "0.14.6"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -695,7 +695,9 @@ def test_box_gt_deletion(dataset):
 
     assert response["annotations_processed"] == 1
 
-    job = dataset.delete_annotations()
+    job = dataset.delete_annotations(
+        reference_ids=[TEST_BOX_ANNOTATIONS[0]["reference_id"]]
+    )
     job.sleep_until_complete()
     job_status = job.status()
     assert job_status["status"] == "Completed"
@@ -712,7 +714,9 @@ def test_category_gt_deletion(dataset):
 
     assert response["annotations_processed"] == 1
 
-    job = dataset.delete_annotations()
+    job = dataset.delete_annotations(
+        reference_ids=[TEST_CATEGORY_ANNOTATIONS[0]["reference_id"]]
+    )
     job.sleep_until_complete()
     job_status = job.status()
     assert job_status["status"] == "Completed"
@@ -731,7 +735,9 @@ def test_multicategory_gt_deletion(dataset):
 
     assert response["annotations_processed"] == 1
 
-    job = dataset.delete_annotations()
+    job = dataset.delete_annotations(
+        reference_ids=[TEST_MULTICATEGORY_ANNOTATIONS[0]["reference_id"]]
+    )
     job.sleep_until_complete()
     job_status = job.status()
     assert job_status["status"] == "Completed"


### PR DESCRIPTION
We're deprecating the `None` value which deletes all annotations due to [this SEV](https://scaleapi.slack.com/archives/C01U1N13Q7N/p1657210698221589)