### PR TITLE
XFAIL race conditioning flaky test

### DIFF
--- a/tests/validate/test_scenario_test.py
+++ b/tests/validate/test_scenario_test.py
@@ -25,6 +25,9 @@ def test_scenario_test_metric_creation(CLIENT, annotations, scenario_test):
     assert scenario_test_metric in criteria
 
 
+@pytest.xfail(
+    reason="Race-condition with other tests and __post_init__ pattern. Need to refactor."
+)
 def test_list_scenario_test(CLIENT, test_slice, annotations):
     test_name = "scenario_test_" + get_uuid()  # use uuid to make unique
 


### PR DESCRIPTION
This test is failing due to trying to get the info of a test that is deleted in a parallel test. The long term solution is getting rid of the `__post_init__` and get all the information from a single listing call but to get rid of the flake we start by `XFAIL`ing .