### PR TITLE
Speed up slices and add client.slices for all customer slices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Important: Don't change this otherwise we will stop testing the earliest
       # python version we have to support.
       - image: python:3.6-buster
-    resource_class: small
+    resource_class: medium
     parallelism: 6
     steps:
       - checkout # checkout source code to working directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.11](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.12) - 2022-08-05
+## [0.14.13](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.13) - 2022-08-09
+
+### Added
+- client.slices to list all of users slices independent of dataset
+
+### Fixed
+- Validate unit test listing and evaluation history listing. Now uses new bulk fetch endpoints for faster listing.
+
+
+## [0.14.12](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.12) - 2022-08-05
 
 ### Added
 - Added auto-paginated `Slice.export_predictions_generator`
+
 ### Fixed
 - Change `{Dataset,Slice}.items_and_annotation_generator` to work with improved paginate endpoint
 

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -235,6 +235,12 @@ class NucleusClient:
         """
         return self.list_jobs()
 
+    @property
+    def slices(self) -> List[Slice]:
+        response = self.make_request({}, "slice/", requests.get)
+        slices = [Slice.from_request(info, self) for info in response]
+        return slices
+
     @deprecated(msg="Use the NucleusClient.models property in the future.")
     def list_models(self) -> List[Model]:
         return self.models

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -86,9 +86,16 @@ class Slice:
         instance = cls(request["id"], client)
         instance._name = request.get("name", None)
         instance._dataset_id = request.get("dataset_id", None)
-        instance._created_at = datetime.datetime.fromisoformat(
-            request.get("created_at").rstrip("Z")
-        )
+        created_at_str = request.get("created_at").rstrip("Z")
+        if hasattr(datetime.datetime, "fromisoformat"):
+            instance._created_at = datetime.datetime.fromisoformat(
+                created_at_str
+            )
+        else:
+            fmt_str = r"%Y-%m-%dT%H:%M:%S.%f"  # replaces the fromisoformatm, not available in python 3.6
+            instance._created_at = datetime.datetime.strptime(
+                created_at_str, fmt_str
+            )
         instance._pending_job_count = request.get("pending_job_count", None)
         return instance
 

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -1,5 +1,6 @@
+import datetime
 import warnings
-from typing import Dict, Iterable, List, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import requests
 
@@ -49,15 +50,47 @@ class Slice:
         self._client = client
         self._name = None
         self._dataset_id = None
+        self._created_at = None
+        self._pending_job_count = None
 
     def __repr__(self):
-        return f"Slice(slice_id='{self.id}', client={self._client})"
+        return f"Slice(slice_id='{self.id}', name={self._name}, dataset_id={self._dataset_id})"
 
     def __eq__(self, other):
         if self.id == other.id:
             if self._client == other._client:
                 return True
         return False
+
+    @property
+    def created_at(self) -> Optional[datetime.datetime]:
+        """Timestamp of creation of the slice
+
+        Returns:
+            datetime of creation or None if not created yet
+        """
+        if self._created_at is None:
+            self._created_at = self.info().get("created_at", None)
+        return self._created_at
+
+    @property
+    def pending_job_count(self) -> Optional[int]:
+        if self._pending_job_count is None:
+            self._pending_job_count = self.info().get(
+                "pending_job_count", None
+            )
+        return self._pending_job_count
+
+    @classmethod
+    def from_request(cls, request, client):
+        instance = cls(request["id"], client)
+        instance._name = request.get("name", None)
+        instance._dataset_id = request.get("dataset_id", None)
+        instance._created_at = datetime.datetime.fromisoformat(
+            request.get("created_at").rstrip("Z")
+        )
+        instance._pending_job_count = request.get("pending_job_count", None)
+        return instance
 
     @property
     def slice_id(self):

--- a/nucleus/validate/client.py
+++ b/nucleus/validate/client.py
@@ -131,12 +131,13 @@ class Validate:
             A list of ScenarioTest objects.
         """
         response = self.connection.get(
-            "validate/scenario_test",
+            "validate/scenario_test/details",
         )
-        return [
-            ScenarioTest(test_id, self.connection)
-            for test_id in response["scenario_test_ids"]
+        tests = [
+            ScenarioTest.from_response(payload, self.connection)
+            for payload in response
         ]
+        return tests
 
     def delete_scenario_test(self, scenario_test_id: str) -> bool:
         """Deletes a Scenario Test. ::

--- a/nucleus/validate/client.py
+++ b/nucleus/validate/client.py
@@ -107,13 +107,17 @@ class Validate:
             ).dict(),
             "validate/scenario_test",
         )
-        return ScenarioTest(response[SCENARIO_TEST_ID_KEY], self.connection)
+        return ScenarioTest.from_id(
+            response[SCENARIO_TEST_ID_KEY], self.connection
+        )
 
     def get_scenario_test(self, scenario_test_id: str) -> ScenarioTest:
         response = self.connection.get(
             f"validate/scenario_test/{scenario_test_id}",
         )
-        return ScenarioTest(response["unit_test"]["id"], self.connection)
+        return ScenarioTest.from_id(
+            response["unit_test"]["id"], self.connection
+        )
 
     @property
     def scenario_tests(self) -> List[ScenarioTest]:

--- a/nucleus/validate/data_transfer_objects/scenario_test_evaluations.py
+++ b/nucleus/validate/data_transfer_objects/scenario_test_evaluations.py
@@ -5,14 +5,6 @@ from pydantic import validator
 from nucleus.pydantic_base import ImmutableModel
 
 
-class EvalDetail(ImmutableModel):
-    id: str
-
-
-class GetEvalHistory(ImmutableModel):
-    evaluations: List[EvalDetail]
-
-
 class EvaluationResult(ImmutableModel):
     item_ref_id: str
     score: float

--- a/nucleus/validate/scenario_test.py
+++ b/nucleus/validate/scenario_test.py
@@ -52,13 +52,13 @@ class ScenarioTest:
     slice_id: str = field(init=False)
     baseline_model_id: Optional[str] = None
 
-    def __post_init__(self):
-        # TODO(gunnar): Remove this pattern. It's too slow. We should get all the info required in one call
-        response = self.connection.get(
-            f"validate/scenario_test/{self.id}/info",
-        )
-        self.name = response[NAME_KEY]
-        self.slice_id = response[SLICE_ID_KEY]
+    @classmethod
+    def from_response(cls, response, connection: Connection):
+        instance = cls(response["id"], connection)
+        instance.name = response[NAME_KEY]
+        instance.slice_id = response[SLICE_ID_KEY]
+        instance.baseline_model_id = response.get("baseline_model_id", None)
+        return instance
 
     def add_eval_function(
         self, eval_function: EvalFunction

--- a/nucleus/validate/scenario_test.py
+++ b/nucleus/validate/scenario_test.py
@@ -50,6 +50,17 @@ class ScenarioTest:
     baseline_model_id: Optional[str] = None
 
     @classmethod
+    def from_id(cls, unit_test_id: str, connection: Connection):
+        # TODO(gunnar): Remove this pattern. It's too slow. We should get all the info required in one call
+        response = connection.get(
+            f"validate/scenario_test/{unit_test_id}/info",
+        )
+        instance = cls(unit_test_id, connection)
+        instance.name = response[NAME_KEY]
+        instance.slice_id = response[SLICE_ID_KEY]
+        return instance
+
+    @classmethod
     def from_response(cls, response, connection: Connection):
         instance = cls(response["id"], connection)
         instance.name = response[NAME_KEY]

--- a/nucleus/validate/scenario_test.py
+++ b/nucleus/validate/scenario_test.py
@@ -18,10 +18,7 @@ from .constants import (
     THRESHOLD_KEY,
     ThresholdComparison,
 )
-from .data_transfer_objects.scenario_test_evaluations import (
-    EvaluationResult,
-    GetEvalHistory,
-)
+from .data_transfer_objects.scenario_test_evaluations import EvaluationResult
 from .data_transfer_objects.scenario_test_metric import AddScenarioTestFunction
 from .eval_functions.available_eval_functions import (
     EvalFunction,
@@ -148,13 +145,13 @@ class ScenarioTest:
             A list of :class:`ScenarioTestEvaluation` objects.
         """
         response = self.connection.get(
-            f"validate/scenario_test/{self.id}/eval_history",
+            f"validate/scenario_test/{self.id}/eval_history/details",
         )
-        eval_history = GetEvalHistory.parse_obj(response)
-        return [
-            ScenarioTestEvaluation(evaluation.id, self.connection)
-            for evaluation in eval_history.evaluations
+        evaluations = [
+            ScenarioTestEvaluation.from_request(eval_payload, self.connection)
+            for eval_payload in response
         ]
+        return evaluations
 
     def get_items(self) -> List[DatasetItem]:
         response = self.connection.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.13"
+version = "0.14.14"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.12"
+version = "0.14.13"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -35,15 +35,6 @@ def slc(CLIENT, dataset):
     CLIENT.delete_slice(slc.id)
 
 
-def test_reprs():
-    # Have to define here in order to have access to all relevant objects
-    def test_repr(test_object: any):
-        assert eval(str(test_object)) == test_object
-
-    client = NucleusClient(api_key="fake_key")
-    test_repr(Slice(slice_id="fake_slice_id", client=client))
-
-
 def test_slice_create_and_delete_and_list(dataset: Dataset):
     ds_items = dataset.items
 


### PR DESCRIPTION
We were lacking a proper slice listing mechanism that wasn't tied to a dataset. This introduces a very fast way of listing all of our slices. Tied to https://github.com/scaleapi/scaleapi/pull/44079

This can be tested locally by attaching 