### PR TITLE
Remove IOU non-max-suppression and ignore non taxonomy classes from mean calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.11](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.12) - 2022-08-05
+## [0.14.13](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.13) - 2022-08-10
+
+### Fixed
+- Validate Segmentation IOU being thresholded and non max suppressed.
+- Validate Segmentation metrics now ignore out of taxonomy indexes for metrics
+
+## [0.14.12](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.12) - 2022-08-05
 
 ### Added
 - Added auto-paginated `Slice.export_predictions_generator`

--- a/nucleus/metrics/segmentation_to_poly_metrics.py
+++ b/nucleus/metrics/segmentation_to_poly_metrics.py
@@ -252,7 +252,6 @@ class SegmentationToPolyIOU(SegmentationMaskToPolyMetric):
             metric = SegmentationIOU(
                 self.annotation_filters,
                 self.prediction_filters,
-                self.iou_threshold,
             )
         else:
             metric = PolygonIOU(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.12"
+version = "0.14.13"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Problems reported by customer. We now do not threshold IOU calculations and ignore non taxonomy classes from the mean reporting.