### PR TITLE
Add metadata support for scene categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.18](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.18) - 2022-08-16
+
+### Added
+- Metadata and confidence support for scene categories
+
 ## [0.14.17](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.17) - 2022-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.14.16](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.16) - 2022-08-12
 
 ### Added
-- Scene cateogorization support
+- Scene categorization support
 
 ## [0.14.15](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.15) - 2022-08-11
 

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -902,12 +902,15 @@ class SceneCategoryAnnotation(Annotation):
 
     ::
 
-        from nucleus import CategoryAnnotation
+        from nucleus import SceneCategoryAnnotation
 
         category = SceneCategoryAnnotation(
             label="running",
             reference_id="scene_1",
             taxonomy_name="action",
+            metadata={
+                "weather": "clear",
+            },
         )
 
     Parameters:
@@ -915,12 +918,15 @@ class SceneCategoryAnnotation(Annotation):
         reference_id (str): User-defined ID of the scene to which to apply this annotation.
         taxonomy_name (Optional[str]): The name of the taxonomy this annotation conforms to.
           See :meth:`Dataset.add_taxonomy`.
+        metadata: Arbitrary key/value dictionary of info to attach to this annotation.
+            Strings, floats and ints are supported best by querying and insights
+            features within Nucleus. For more details see our `metadata guide
+            <https://nucleus.scale.com/docs/upload-metadata>`_.
     """
 
     label: str
     reference_id: str
     taxonomy_name: Optional[str] = None
-    # todo(546247): add metadata support when required
     metadata: Optional[Dict] = field(default_factory=dict)
 
     @classmethod
@@ -929,6 +935,7 @@ class SceneCategoryAnnotation(Annotation):
             label=payload[LABEL_KEY],
             reference_id=payload[REFERENCE_ID_KEY],
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
+            metadata=payload.get(METADATA_KEY, {}),
         )
 
     def to_payload(self) -> dict:
@@ -937,6 +944,7 @@ class SceneCategoryAnnotation(Annotation):
             TYPE_KEY: CATEGORY_TYPE,
             GEOMETRY_KEY: {},
             REFERENCE_ID_KEY: self.reference_id,
+            METADATA_KEY: self.metadata,
         }
         if self.taxonomy_name is not None:
             payload[TAXONOMY_NAME_KEY] = self.taxonomy_name

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -575,12 +575,64 @@ class CategoryPrediction(CategoryAnnotation):
 class SceneCategoryPrediction(SceneCategoryAnnotation):
     """A prediction of a category for a scene.
 
+    ::
+
+        from nucleus import SceneCategoryPrediction
+
+        category = SceneCategoryPrediction(
+            label="running",
+            reference_id="scene_1",
+            taxonomy_name="action",
+            confidence=0.83,
+            metadata={
+                "weather": "clear",
+            },
+        )
+
     Parameters:
         label: The label for this annotation (e.g. action, subject, scenario).
         reference_id: The reference ID of the scene you wish to apply this annotation to.
         taxonomy_name: The name of the taxonomy this annotation conforms to.
           See :meth:`Dataset.add_taxonomy`.
+        confidence: 0-1 indicating the confidence of the prediction.
+        metadata: Arbitrary key/value dictionary of info to attach to this annotation.
+            Strings, floats and ints are supported best by querying and insights
+            features within Nucleus. For more details see our `metadata guide
+            <https://nucleus.scale.com/docs/upload-metadata>`_.
     """
+
+    def __init__(
+        self,
+        label: str,
+        reference_id: str,
+        taxonomy_name: Optional[str] = None,
+        confidence: Optional[float] = None,
+        metadata: Optional[Dict] = None,
+    ):
+        super().__init__(
+            label=label,
+            taxonomy_name=taxonomy_name,
+            reference_id=reference_id,
+            metadata=metadata,
+        )
+        self.confidence = confidence
+
+    def to_payload(self) -> dict:
+        payload = super().to_payload()
+        if self.confidence is not None:
+            payload[CONFIDENCE_KEY] = self.confidence
+
+        return payload
+
+    @classmethod
+    def from_json(cls, payload: dict):
+        return cls(
+            label=payload.get(LABEL_KEY, 0),
+            taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
+            reference_id=payload[REFERENCE_ID_KEY],
+            confidence=payload.get(CONFIDENCE_KEY, None),
+            metadata=payload.get(METADATA_KEY, {}),
+        )
 
 
 Prediction = Union[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.17"
+version = "0.14.18"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Added `metadata` to `SceneCategoryAnnotation` and `SceneCategoryPrediction`, as well as `confidence` to `SceneCategoryPrediction`.

https://app.shortcut.com/scaleai/story/546247/nucleus-metadata-support-for-scene-categorization