### PR TITLE
Fix model metrics test

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,8 +91,6 @@ def test_new_model_endpoints(CLIENT, dataset: Dataset):
 
     dataset.upload_predictions(model, predictions=predictions)
 
-    dataset.calculate_evaluation_metrics(model)
-
     predictions_export = dataset.export_predictions(model)
 
     assert_box_prediction_matches_dict(


### PR DESCRIPTION
The model metrics are not being used anywhere in the test.

This call is causing errored jobs on the backend because by the time the async job starts the test is completed and dataset yielded in the test fixture is deleted from the database.