### PR TITLE
Skip unhappy path category tests

### DIFF
--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -263,6 +263,9 @@ def test_default_category_gt_upload(dataset):
     )
 
 
+@pytest.mark.skip(
+    reason="Triggers SFN failed warning - need to find better unhappy tests"
+)
 def test_non_existent_taxonomy_category_gt_upload(dataset):
     annotation = CategoryAnnotation.from_json(
         TEST_NONEXISTENT_TAXONOMY_CATEGORY_ANNOTATION[0]
@@ -331,6 +334,9 @@ def test_scene_category_gt_upload(scene_category_dataset):
     assert response["annotations_ignored"] == 0
 
 
+@pytest.mark.skip(
+    reason="Triggers SFN failed warning - need to find better unhappy tests"
+)
 def test_non_existent_taxonomy_scene_category_gt_upload(
     scene_category_dataset,
 ):
@@ -836,7 +842,9 @@ def test_default_category_gt_upload_async(dataset):
     assert_partial_equality(expected, result)
 
 
-@pytest.mark.skip("Need to adjust error message on taxonomy failure")
+@pytest.mark.skip(
+    reason="Triggers SFN failed warning - need to find better unhappy tests"
+)
 @pytest.mark.integration
 def test_non_existent_taxonomy_category_gt_upload_async(dataset):
     annotation = CategoryAnnotation.from_json(


### PR DESCRIPTION
This skips tests that are testing the unhappy path that are triggering SFN warnings.