### PR TITLE
[Launch] Add a utility for users to test their Launch+Nucleus bundles locally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,3 +24,6 @@ reports=no
 
 [tool.pylint.FORMAT]
 max-line-length=79
+
+[tool.pylint.MASTER]
+extension-pkg-whitelist=pydantic

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -23,7 +23,7 @@ def verify_box_output(bbox_list):
         geometry_keys = set(bbox["geometry"].keys())
         if geometry_keys != _GEOMETRY_KEYS:
             raise ValueError(
-                f"Keys {geometry_keys} in geometry not equal to {_GEOMETRY_KEYS}"
+                f"Keys {geometry_keys} in geometry not equal to expected {_GEOMETRY_KEYS}"
             )
         if bbox["type"] != "box":
             raise ValueError(

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -39,12 +39,13 @@ def visualize_bbox_launch_bundle(
     model: Any = None,
     show_image: bool = False,
     max_boxes: int = 5,
-):
+) -> Image:
     """
     Run this function locally to visualize what your Launch bundle will do on a local image
     Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
     any coordinate systems used for the image.
     Will display the image in a separate window if show_image == True.
+    Returns the image
     """
     # Basically do the same thing as what Launch does but locally
 
@@ -64,11 +65,14 @@ def visualize_bbox_launch_bundle(
     output = predict_fn(img_bytes)
     verify_box_output(output)
 
+    image = Image.open(io.BytesIO(img_bytes))
+    draw = ImageDraw.Draw(image)
+    for bbox in output[:max_boxes]:
+        geo = bbox["geometry"]
+        x, y, w, h = geo["x"], geo["y"], geo["width"], geo["height"]
+        draw.rectangle([(x, y), (x + w, y + h)])
+
     if show_image:
-        image = Image.open(io.BytesIO(img_bytes))
-        draw = ImageDraw.Draw(image)
-        for bbox in output[:max_boxes]:
-            geo = bbox["geometry"]
-            x, y, w, h = geo["x"], geo["y"], geo["width"], geo["height"]
-            draw.rectangle([(x, y), (x + w, y + h)])
         image.show()
+
+    return image

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -42,7 +42,7 @@ def visualize_bbox_launch_bundle(
 ):
     # Basically do the same thing as what Launch does but locally
 
-    if (model is None) ^ (load_model_fn is None):
+    if not (model is None) ^ (load_model_fn is None):
         raise ValueError(
             "Exactly one of `model` and `load_model_fn` must not be None."
         )

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -4,26 +4,28 @@ from typing import Any, Callable
 from PIL import Image, ImageDraw
 
 # From scaleapi/server/src/lib/select/api/types.ts
-_TOP_LEVEL_REQUIRED_KEYS = {"geometry", "type"}
+_TOP_LEVEL_BOX_REQUIRED_KEYS = {"geometry", "type"}
 _TOP_LEVEL_OPTIONAL_KEYS = {"label", "confidence", "classPdf", "metadata"}
 # TODO idk which ones are right for nucleus
-_TOP_LEVEL_ALL_KEYS = _TOP_LEVEL_REQUIRED_KEYS.union(_TOP_LEVEL_OPTIONAL_KEYS)
-_GEOMETRY_KEYS = {"x", "y", "width", "height"}
+_TOP_LEVEL_BOX_ALL_KEYS = _TOP_LEVEL_BOX_REQUIRED_KEYS.union(
+    _TOP_LEVEL_OPTIONAL_KEYS
+)
+_BOX_GEOMETRY_KEYS = {"x", "y", "width", "height"}
 
 
 def verify_box_output(bbox_list):
     for bbox in bbox_list:
         keys = set(bbox.keys())
-        missing_keys = _TOP_LEVEL_REQUIRED_KEYS.difference(keys)
-        extra_keys = keys.difference(_TOP_LEVEL_ALL_KEYS)
+        missing_keys = _TOP_LEVEL_BOX_REQUIRED_KEYS.difference(keys)
+        extra_keys = keys.difference(_TOP_LEVEL_BOX_ALL_KEYS)
         if len(missing_keys):
             raise ValueError(f"Missing keys {missing_keys} in box annotation")
         if len(extra_keys):
             raise ValueError(f"Extra keys {extra_keys} in box annotation")
         geometry_keys = set(bbox["geometry"].keys())
-        if geometry_keys != _GEOMETRY_KEYS:
+        if geometry_keys != _BOX_GEOMETRY_KEYS:
             raise ValueError(
-                f"Keys {geometry_keys} in geometry not equal to expected {_GEOMETRY_KEYS}"
+                f"Keys {geometry_keys} in geometry not equal to expected {_BOX_GEOMETRY_KEYS}"
             )
         if bbox["type"] != "box":
             raise ValueError(

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -137,6 +137,10 @@ def _run_model(
     return predict_fn(input_bytes)
 
 
+_FILL_COLOR = (0, 255, 0, 50)
+_OUTLINE_COLOR = (0, 255, 0, 255)
+
+
 def visualize_box_launch_bundle(
     img_file: str,
     load_predict_fn: Callable,
@@ -161,11 +165,13 @@ def visualize_box_launch_bundle(
     verify_box_output(output)
 
     image = Image.open(io.BytesIO(img_bytes))
-    draw = ImageDraw.Draw(image)
+    draw = ImageDraw.Draw(image, "RGBA")
     for bbox in output[:max_annotations]:
         geo = bbox["geometry"]
         x, y, w, h = geo["x"], geo["y"], geo["width"], geo["height"]
-        draw.rectangle([(x, y), (x + w, y + h)])
+        draw.rectangle(
+            [(x, y), (x + w, y + h)], outline=_OUTLINE_COLOR, fill=_FILL_COLOR
+        )
 
     if show_image:
         image.show()
@@ -216,11 +222,11 @@ def visualize_line_launch_bundle(
     verify_line_output(output)
 
     image = Image.open(io.BytesIO(img_bytes))
-    draw = ImageDraw.Draw(image)
+    draw = ImageDraw.Draw(image, "RGBA")
     for bbox in output[:max_annotations]:
         geo = bbox["geometry"]
         vertices = [(v["x"], v["y"]) for v in geo["vertices"]]
-        draw.line(vertices)
+        draw.line(vertices, fill=_OUTLINE_COLOR)
 
     if show_image:
         image.show()
@@ -254,11 +260,11 @@ def visualize_polygon_launch_bundle(
     verify_polygon_output(output)
 
     image = Image.open(io.BytesIO(img_bytes))
-    draw = ImageDraw.Draw(image)
+    draw = ImageDraw.Draw(image, "RGBA")
     for bbox in output[:max_annotations]:
         geo = bbox["geometry"]
         vertices = [(v["x"], v["y"]) for v in geo["vertices"]]
-        draw.polygon(vertices)
+        draw.polygon(vertices, outline=_OUTLINE_COLOR, fill=_FILL_COLOR)
 
     if show_image:
         image.show()

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -1,0 +1,68 @@
+import io
+from typing import Any, Callable, Dict
+
+from PIL import Image, ImageDraw
+
+# From scaleapi/server/src/lib/select/api/types.ts
+_TOP_LEVEL_REQUIRED_KEYS = {"geometry", "type"}
+_TOP_LEVEL_OPTIONAL_KEYS = {"label", "confidence", "classPdf", "metadata"}
+# TODO idk which ones are right for nucleus
+_TOP_LEVEL_ALL_KEYS = _TOP_LEVEL_REQUIRED_KEYS.union(_TOP_LEVEL_OPTIONAL_KEYS)
+_GEOMETRY_KEYS = {"x", "y", "width", "height"}
+
+
+def verify_box_output(bbox_list):
+    for bbox in bbox_list:
+        keys = set(bbox.keys())
+        missing_keys = _TOP_LEVEL_REQUIRED_KEYS.difference(keys)
+        extra_keys = keys.difference(_TOP_LEVEL_ALL_KEYS)
+        if len(missing_keys):
+            raise ValueError(f"Missing keys {missing_keys} in box annotation")
+        if len(extra_keys):
+            raise ValueError(f"Extra keys {extra_keys} in box annotation")
+        geometry_keys = set(bbox["geometry"].keys())
+        if geometry_keys != _GEOMETRY_KEYS:
+            raise ValueError(
+                f"Keys {geometry_keys} in geometry not equal to {_GEOMETRY_KEYS}"
+            )
+        if bbox["type"] != "box":
+            raise ValueError(
+                f"Bounding box type {bbox['type']} should equal 'box'"
+            )
+
+
+def visualize_bbox_launch_bundle(
+    img_file: str,
+    config: Dict[str, Any],
+    load_predict_fn: Callable,
+    load_model_fn: Callable = None,
+    model: Any = None,
+    show_image: bool = False,
+    max_boxes: int = 5,
+):
+    # Basically do the same thing as what Launch does but locally
+
+    if (model is None) ^ (load_model_fn is None):
+        raise ValueError(
+            "Exactly one of `model` and `load_model_fn` must not be None."
+        )
+
+    if load_model_fn:
+        model = load_model_fn(config)
+
+    predict_fn = load_predict_fn(config, model)
+
+    with open(img_file, "rb") as f:
+        img_bytes = f.read()
+
+    output = predict_fn(img_bytes)
+    verify_box_output(output)
+
+    if show_image:
+        image = Image.open(io.BytesIO(img_bytes))
+        draw = ImageDraw.Draw(image)
+        for bbox in output[:max_boxes]:
+            geo = bbox["geometry"]
+            x, y, w, h = geo["x"], geo["y"], geo["width"], geo["height"]
+            draw.rectangle([(x, y), (x + w, y + h)])
+        image.show()

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -40,6 +40,12 @@ def visualize_bbox_launch_bundle(
     show_image: bool = False,
     max_boxes: int = 5,
 ):
+    """
+    Run this function locally to visualize what your Launch bundle will do on a local image
+    Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
+    any coordinate systems used for the image.
+    Will display the image in a separate window if show_image == True.
+    """
     # Basically do the same thing as what Launch does but locally
 
     if not (model is None) ^ (load_model_fn is None):

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -154,7 +154,19 @@ def visualize_box_launch_bundle(
     Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
     any coordinate systems used for the image.
     Will display the image in a separate window if show_image == True.
-    Returns the image
+    Returns the image as well.
+
+    Parameters:
+        img_file: The path to a local image file.
+        load_predict_fn: The load_predict_fn as part of your Launch bundle
+        load_model_fn: The load_model_fn as part of your Launch bundle
+        model: The model as part of your Launch bundle. Note: exactly one of load_model_fn and model must be specified
+        show_image: Whether to automatically pop up the image + predictions in a separate window. Can be useful in a
+          script.
+        max_annotations: How many annotations you want to draw
+
+    Returns:
+        Image: The image with annotations drawn on top.
     """
     # Basically do the same thing as what Launch does but locally
 
@@ -186,7 +198,14 @@ def run_category_launch_bundle(
     model: Any = None,
 ):
     """
-    Not much visualization to be done for category, so we just run it and make sure it works
+    Run this function locally to test if your image categorization model returns a format consumable by Launch + Nucleus
+    Parameters:
+        img_file: The path to a local image file.
+        load_predict_fn: The load_predict_fn as part of your Launch bundle
+        load_model_fn: The load_model_fn as part of your Launch bundle
+        model: The model as part of your Launch bundle. Note: exactly one of load_model_fn and model must be specified
+    Returns:
+        The raw output (as a json) of your categorization model.
     """
     with open(img_file, "rb") as f:
         img_bytes = f.read()
@@ -209,11 +228,21 @@ def visualize_line_launch_bundle(
     Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
     any coordinate systems used for the image.
     Will display the image in a separate window if show_image == True.
-    Returns the image
+    Returns the image as well.
+
+    Parameters:
+        img_file: The path to a local image file.
+        load_predict_fn: The load_predict_fn as part of your Launch bundle
+        load_model_fn: The load_model_fn as part of your Launch bundle
+        model: The model as part of your Launch bundle. Note: exactly one of load_model_fn and model must be specified
+        show_image: Whether to automatically pop up the image + predictions in a separate window. Can be useful in a
+          script.
+        max_annotations: How many annotations you want to draw
+
+    Returns:
+        Image: The image with annotations drawn on top.
     """
     # Basically do the same thing as what Launch does but locally
-    # TODO test
-    # TODO are there even models that return a sequence of lines?
 
     with open(img_file, "rb") as f:
         img_bytes = f.read()
@@ -247,11 +276,21 @@ def visualize_polygon_launch_bundle(
     Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
     any coordinate systems used for the image.
     Will display the image in a separate window if show_image == True.
-    Returns the image
+    Returns the image as well.
+
+    Parameters:
+        img_file: The path to a local image file.
+        load_predict_fn: The load_predict_fn as part of your Launch bundle
+        load_model_fn: The load_model_fn as part of your Launch bundle
+        model: The model as part of your Launch bundle. Note: exactly one of load_model_fn and model must be specified
+        show_image: Whether to automatically pop up the image + predictions in a separate window. Can be useful in a
+          script.
+        max_annotations: How many annotations you want to draw
+
+    Returns:
+        Image: The image with annotations drawn on top.
     """
     # Basically do the same thing as what Launch does but locally
-    # TODO test
-    # TODO are there even models that return a sequence of lines?
 
     with open(img_file, "rb") as f:
         img_bytes = f.read()

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 from PIL import Image, ImageDraw
 
@@ -33,7 +33,6 @@ def verify_box_output(bbox_list):
 
 def visualize_bbox_launch_bundle(
     img_file: str,
-    config: Dict[str, Any],
     load_predict_fn: Callable,
     load_model_fn: Callable = None,
     model: Any = None,
@@ -55,9 +54,9 @@ def visualize_bbox_launch_bundle(
         )
 
     if load_model_fn:
-        model = load_model_fn(config)
+        model = load_model_fn()
 
-    predict_fn = load_predict_fn(config, model)
+    predict_fn = load_predict_fn(model)
 
     with open(img_file, "rb") as f:
         img_bytes = f.read()

--- a/nucleus/test_launch_integration.py
+++ b/nucleus/test_launch_integration.py
@@ -8,6 +8,11 @@ from pydantic import BaseModel, Extra, ValidationError
 # These classes specify how user models must pass output to Launch + Nucleus.
 
 
+class PointModel(BaseModel, extra=Extra.forbid):
+    x: float
+    y: float
+
+
 class BoxGeometryModel(BaseModel, extra=Extra.forbid):
     x: float
     y: float
@@ -37,6 +42,19 @@ class CategoryAnnotationModel(BaseModel, extra=Extra.forbid):
     metadata: Optional[Dict[str, Any]] = None
 
 
+class LineGeometryModel(BaseModel, extra=Extra.forbid):
+    vertices: List[PointModel]
+
+
+class LineAnnotationModel(BaseModel, extra=Extra.forbid):
+    geometry: LineGeometryModel
+    type: str
+    label: Optional[str] = None
+    confidence: Optional[float] = None
+    classPdf: Optional[Dict[str, float]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
 def verify_output(
     annotation_list: List[Dict[str, Any]],
     model: Type[BaseModel],
@@ -44,8 +62,7 @@ def verify_output(
 ):
     for annotation in annotation_list:
         try:
-            obj = model.parse_obj(annotation)
-            print(obj)
+            model.parse_obj(annotation)
         except ValidationError as e:
             raise ValueError("Failed validation") from e
         if annotation["type"] != annotation_type:
@@ -71,13 +88,40 @@ def verify_category_output(category_list):
     )
 
 
+def verify_line_output(line_list):
+    annotation_type = "line"
+    return verify_output(
+        line_list,
+        LineAnnotationModel,
+        annotation_type,
+    )
+
+
+def _run_model(
+    input_bytes: bytes,
+    load_predict_fn: Callable,
+    load_model_fn: Optional[Callable],
+    model: Optional[Any],
+):
+    if not (model is None) ^ (load_model_fn is None):
+        raise ValueError(
+            "Exactly one of `model` and `load_model_fn` must not be None."
+        )
+
+    if load_model_fn:
+        model = load_model_fn()
+
+    predict_fn = load_predict_fn(model)
+    return predict_fn(input_bytes)
+
+
 def visualize_box_launch_bundle(
     img_file: str,
     load_predict_fn: Callable,
     load_model_fn: Callable = None,
     model: Any = None,
     show_image: bool = False,
-    max_boxes: int = 5,
+    max_annotations: int = 5,
 ) -> Image:
     """
     Run this function locally to visualize what your Launch bundle will do on a local image
@@ -88,28 +132,74 @@ def visualize_box_launch_bundle(
     """
     # Basically do the same thing as what Launch does but locally
 
-    if not (model is None) ^ (load_model_fn is None):
-        raise ValueError(
-            "Exactly one of `model` and `load_model_fn` must not be None."
-        )
-
-    if load_model_fn:
-        model = load_model_fn()
-
-    predict_fn = load_predict_fn(model)
-
     with open(img_file, "rb") as f:
         img_bytes = f.read()
 
-    output = predict_fn(img_bytes)
+    output = _run_model(img_bytes, load_predict_fn, load_model_fn, model)
     verify_box_output(output)
 
     image = Image.open(io.BytesIO(img_bytes))
     draw = ImageDraw.Draw(image)
-    for bbox in output[:max_boxes]:
+    for bbox in output[:max_annotations]:
         geo = bbox["geometry"]
         x, y, w, h = geo["x"], geo["y"], geo["width"], geo["height"]
         draw.rectangle([(x, y), (x + w, y + h)])
+
+    if show_image:
+        image.show()
+
+    return image
+
+
+def run_category_launch_bundle(
+    img_file: str,
+    load_predict_fn: Callable,
+    load_model_fn: Callable = None,
+    model: Any = None,
+):
+    """
+    Not much visualization to be done for category, so we just run it and make sure it works
+    """
+    with open(img_file, "rb") as f:
+        img_bytes = f.read()
+
+    output = _run_model(img_bytes, load_predict_fn, load_model_fn, model)
+    verify_category_output(output)
+    return output
+
+
+def visualize_line_launch_bundle(
+    img_file: str,
+    load_predict_fn: Callable,
+    load_model_fn: Callable = None,
+    model: Any = None,
+    show_image: bool = False,
+    max_annotations: int = 5,
+) -> Image:
+    """
+    Run this function locally to visualize what your Launch bundle will do on a local image
+    Intended to verify that your Launch bundle returns annotations in the correct format, as well as sanity check
+    any coordinate systems used for the image.
+    Will display the image in a separate window if show_image == True.
+    Returns the image
+    """
+    # Basically do the same thing as what Launch does but locally
+    # TODO test
+    # TODO are there even models that return a sequence of lines?
+
+    with open(img_file, "rb") as f:
+        img_bytes = f.read()
+
+    output = _run_model(img_bytes, load_predict_fn, load_model_fn, model)
+    verify_line_output(output)
+
+    image = Image.open(io.BytesIO(img_bytes))
+    draw = ImageDraw.Draw(image)
+    for bbox in output[:max_annotations]:
+        geo = bbox["geometry"]
+        vertices = geo["vertices"]
+        for v1, v2 in zip(vertices[:-1], vertices[1:]):
+            draw.line(v1, v2)
 
     if show_image:
         image.show()

--- a/tests/test_test_launch_integration.py
+++ b/tests/test_test_launch_integration.py
@@ -1,0 +1,162 @@
+import pytest
+
+from nucleus.test_launch_integration import verify_box_output
+
+
+def test_verify_box_output_good():
+    good_bboxes = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "car",
+            "confidence": 0.99,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+    ]
+    verify_box_output(good_bboxes)
+
+
+def test_verify_box_output_bad():
+    # missing type
+    bad_bboxes_1 = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "label": "car",
+            "confidence": 0.99,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+    ]
+    # extra top level key
+    bad_bboxes_2 = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "car",
+            "confidence": 0.99,
+            "extra": "extra",
+        },
+    ]
+    # missing item in geometry
+    bad_bboxes_3 = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1},
+            "type": "box",
+            "label": "car",
+            "confidence": 0.99,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+    ]
+    # extra item in geometry
+    bad_bboxes_4 = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {
+                "x": 1,
+                "y": 1,
+                "width": 1,
+                "height": 1,
+                "extra": "extra",
+            },
+            "type": "box",
+            "label": "car",
+            "confidence": 0.99,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+    ]
+    # incorrect type
+    bad_bboxes_5 = [
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "truck",
+            "confidence": 0.98,
+        },
+        {
+            "geometry": {
+                "x": 1,
+                "y": 1,
+                "width": 1,
+                "height": 1,
+            },
+            "type": "polygon",
+            "label": "car",
+            "confidence": 0.99,
+        },
+        {
+            "geometry": {"x": 1, "y": 1, "width": 1, "height": 1},
+            "type": "box",
+            "label": "person",
+            "confidence": 0.97,
+        },
+    ]
+
+    bad_bboxes = [
+        bad_bboxes_1,
+        bad_bboxes_2,
+        bad_bboxes_3,
+        bad_bboxes_4,
+        bad_bboxes_5,
+    ]
+
+    for bad_bbox in bad_bboxes:
+        try:
+            verify_box_output(bad_bbox)
+        except ValueError:
+            pass
+        else:
+            pytest.fail("Expected verify_box_output to throw ValueError")

--- a/tests/test_test_launch_integration.py
+++ b/tests/test_test_launch_integration.py
@@ -9,6 +9,24 @@ from nucleus.test_launch_integration import (
     verify_polygon_output,
 )
 
+_GOOD_POINT_ARRAY = [
+    {"x": 1, "y": 2},
+    {"x": 3, "y": 4},
+    {"x": 5, "y": 6},
+]
+
+_BAD_POINT_ARRAY_KEYS = [
+    {"x": 1, "z": 2},
+    {"x": 3, "y": 4},
+    {"x": 5, "y": 6},
+]
+
+_BAD_POINT_ARRAY_TYPES = [
+    {"x": 1, "y": "hi"},
+    {"x": 3, "y": "here"},
+    {"x": 5, "y": "there"},
+]
+
 
 def _assert_all_valueerror(fn: Callable[[Any], Any], items: List[Any]):
     for item in items:
@@ -243,3 +261,154 @@ def test_verify_category_output_bad():
     ]
 
     _assert_all_valueerror(verify_category_output, bad_categories)
+
+
+def test_verify_line_output_good():
+    good_line = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "line",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+
+    verify_line_output(good_line)
+
+
+def test_verify_line_output_bad():
+    bad_line_1 = [
+        {
+            "geometry": {"vertices": _BAD_POINT_ARRAY_TYPES},
+            "type": "line",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_line_2 = [
+        {
+            "geometry": {"vertices": _BAD_POINT_ARRAY_KEYS},
+            "type": "line",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_line_3 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "notline",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_line_4 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "line",
+            "label": "label1",
+            "confidence": "extremely",
+        }
+    ]
+    bad_line_5 = [
+        {"geometry": {}, "type": "line", "label": "label1", "confidence": 0.99}
+    ]
+    bad_line_6 = [{"type": "line", "label": "label1", "confidence": 0.99}]
+    bad_line_7 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "line",
+            "label": "label1",
+            "confidence": 0.99,
+            "extra": "extra",
+        }
+    ]
+
+    bad_lines = [
+        bad_line_1,
+        bad_line_2,
+        bad_line_3,
+        bad_line_4,
+        bad_line_5,
+        bad_line_6,
+        bad_line_7,
+    ]
+    _assert_all_valueerror(verify_line_output, bad_lines)
+
+
+def test_verify_polygon_output_good():
+    good_polygon = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+
+    verify_polygon_output(good_polygon)
+
+
+def test_verify_polygon_output_bad():
+    bad_polygon_1 = [
+        {
+            "geometry": {"vertices": _BAD_POINT_ARRAY_TYPES},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_polygon_2 = [
+        {
+            "geometry": {"vertices": _BAD_POINT_ARRAY_KEYS},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_polygon_3 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "notpolygon",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_polygon_4 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": "extremely",
+        }
+    ]
+    bad_polygon_5 = [
+        {
+            "geometry": {},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": 0.99,
+        }
+    ]
+    bad_polygon_6 = [
+        {"type": "polygon", "label": "label1", "confidence": 0.99}
+    ]
+    bad_polygon_7 = [
+        {
+            "geometry": {"vertices": _GOOD_POINT_ARRAY},
+            "type": "polygon",
+            "label": "label1",
+            "confidence": 0.99,
+            "extra": "extra",
+        }
+    ]
+
+    bad_polygons = [
+        bad_polygon_1,
+        bad_polygon_2,
+        bad_polygon_3,
+        bad_polygon_4,
+        bad_polygon_5,
+        bad_polygon_6,
+        bad_polygon_7,
+    ]
+    _assert_all_valueerror(verify_polygon_output, bad_polygons)


### PR DESCRIPTION
If `show_image=True`, pops up a new window with the image. Also just returns the image with the boxes/lines/polygons drawn on top.

If we want we can use matplotlib.pyplot.imshow to display the image, although it looks uglier inside of the jupyter notebook (and I'd assume uglier as well from a python script)

Jupyter nb: vvv

<img width="593" alt="image" src="https://user-images.githubusercontent.com/69175566/192067559-f50a25ea-a2b8-40a8-9423-67e180c12a67.png">

Previous version: vvv
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/69175566/192019833-14d41550-1171-4841-9cf6-28c8f8ea8e6e.png">


