### PR TITLE
Fix sync ingest for large number of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.20](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.20) - 2022-09-23
+
+### Fixed
+- Local uploads are correctly batched and prevents flooding the network with requests
+
+
 ## [0.14.19](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.19) - 2022-08-26
 
 ### Added

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -158,7 +158,6 @@ class AnnotationUploader:
             requests=requests,
             route=self._route,
             progressbar=progressbar,
-            concurrency=local_file_upload_concurrency,
         )
 
     def get_form_data_and_file_pointers_fn(

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -57,7 +57,6 @@ class AnnotationUploader:
         update: bool = False,
         remote_files_per_upload_request: int = 20,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ):
         """For more details on parameters and functionality, see dataset.annotate."""
         if local_files_per_upload_request > 10:
@@ -84,7 +83,6 @@ class AnnotationUploader:
                     segmentations=segmentations_with_local_files,
                     update=update,
                     local_files_per_upload_request=local_files_per_upload_request,
-                    local_file_upload_concurrency=local_file_upload_concurrency,
                 )
             )
         if segmentations_with_remote_files:
@@ -138,7 +136,6 @@ class AnnotationUploader:
         segmentations: Sequence[SegmentationAnnotation],
         update,
         local_files_per_upload_request: int,
-        local_file_upload_concurrency: int,
     ):
         requests = []
         for i in range(0, len(segmentations), local_files_per_upload_request):

--- a/nucleus/async_utils.py
+++ b/nucleus/async_utils.py
@@ -123,7 +123,7 @@ async def form_data_request_helper(
     """
     async with aiohttp.ClientSession() as session:
         tasks = [
-            asyncio.create_task(
+            asyncio.ensure_future(
                 _post_form_data(
                     client=client,
                     request=request,

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -72,7 +72,7 @@ from .upload_response import UploadResponse
 # pylint: disable=C0302
 
 
-WARN_FOR_LARGE_UPLOAD = 50000
+WARN_FOR_LARGE_UPLOAD = 10000
 WARN_FOR_LARGE_SCENES_UPLOAD = 5
 
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -257,7 +257,7 @@ class Dataset:
         response = self._client.make_request(
             payload={AUTOTAG_SCORE_THRESHOLD: for_scores_greater_than},
             route=f"dataset/{self.id}/autotag/{autotag_name}/taggedItems",
-            requests_command=requests.get,
+            requests_command=requests.post,
         )
         return response
 

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -336,7 +336,6 @@ class Dataset:
         asynchronous: bool = False,
         remote_files_per_upload_request: int = 20,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ) -> Union[Dict[str, Any], AsyncJob]:
         """Uploads ground truth annotations to the dataset.
 
@@ -381,8 +380,6 @@ class Dataset:
                 request. Segmentations have either local or remote files, if you are
                 getting timeouts while uploading segmentations with local files, you
                 should lower this value from its default of 10. The maximum is 10.
-            local_file_upload_concurrency: Number of concurrent local file uploads.
-
 
         Returns:
             If synchronous, payload describing the upload result::
@@ -414,7 +411,6 @@ class Dataset:
             batch_size=batch_size,
             remote_files_per_upload_request=remote_files_per_upload_request,
             local_files_per_upload_request=local_files_per_upload_request,
-            local_file_upload_concurrency=local_file_upload_concurrency,
         )
 
     def ingest_tasks(self, task_ids: List[str]) -> dict:
@@ -452,7 +448,6 @@ class Dataset:
         batch_size: int = 20,
         asynchronous: bool = False,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ) -> Union[Dict[Any, Any], AsyncJob, UploadResponse]:
         """Appends items or scenes to a dataset.
 
@@ -535,8 +530,6 @@ class Dataset:
                 this if you encounter timeouts.
             local_files_per_upload_request: Optional; default is 10. We recommend
                 lowering this if you encounter timeouts.
-            local_file_upload_concurrency: Optional; default is 30. We recommend
-                lowering this if you encounter gateway timeouts or Cloudflare errors.
         Returns:
             For scenes
                 If synchronous, returns a payload describing the upload result::
@@ -608,7 +601,6 @@ class Dataset:
             update=update,
             batch_size=batch_size,
             local_files_per_upload_request=local_files_per_upload_request,
-            local_file_upload_concurrency=local_file_upload_concurrency,
         )
 
     @deprecated("Prefer using Dataset.append instead.")
@@ -1483,7 +1475,6 @@ class Dataset:
         batch_size: int = 5000,
         remote_files_per_upload_request: int = 20,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ):
         """Uploads predictions and associates them with an existing :class:`Model`.
 
@@ -1541,7 +1532,6 @@ class Dataset:
                 getting timeouts while uploading segmentations with local files, you
                 should lower this value from its default of 10. The maximum is 10.
                 This is only relevant for asynchronous=False
-            local_file_upload_concurrency: Number of concurrent local file uploads.
 
         Returns:
             Payload describing the synchronous upload::
@@ -1579,7 +1569,6 @@ class Dataset:
             update=update,
             remote_files_per_upload_request=remote_files_per_upload_request,
             local_files_per_upload_request=local_files_per_upload_request,
-            local_file_upload_concurrency=local_file_upload_concurrency,
         )
 
     def predictions_iloc(self, model, index):
@@ -1686,7 +1675,6 @@ class Dataset:
         batch_size: int = 20,
         update: bool = False,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ) -> UploadResponse:
         """
         Appends images to a dataset with given dataset_id.
@@ -1700,9 +1688,6 @@ class Dataset:
             local_files_per_upload_request: How large to make each upload request when your
                 files are local. If you get timeouts, you may need to lower this from
                 its default of 10. The maximum is 10.
-            local_file_upload_concurrency: How many local file requests to send
-                concurrently. If you start to see gateway timeouts or cloudflare related
-                errors, you may need to lower this from its default of 30.
 
         Returns:
             UploadResponse
@@ -1720,7 +1705,6 @@ class Dataset:
             batch_size=batch_size,
             update=update,
             local_files_per_upload_request=local_files_per_upload_request,
-            local_file_upload_concurrency=local_file_upload_concurrency,
         )
 
     def update_scene_metadata(

--- a/nucleus/dataset_item_uploader.py
+++ b/nucleus/dataset_item_uploader.py
@@ -38,7 +38,6 @@ class DatasetItemUploader:
         batch_size: int = 5000,
         update: bool = False,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ) -> UploadResponse:
         """
 
@@ -46,9 +45,8 @@ class DatasetItemUploader:
             dataset_items: Items to Upload
             batch_size: How many items to pool together for a single request for items
              without files to upload
-            files_per_upload_request: How many items to pool together for a single
+            local_files_per_upload_request: How many items to pool together for a single
                 request for items with files to upload
-
             update: Update records instead of overwriting
 
         Returns:
@@ -79,7 +77,6 @@ class DatasetItemUploader:
                     items=local_items,
                     update=update,
                     local_files_per_upload_request=local_files_per_upload_request,
-                    local_file_upload_concurrency=local_file_upload_concurrency,
                 )
             )
 
@@ -112,7 +109,6 @@ class DatasetItemUploader:
         items: Sequence[DatasetItem],
         update: bool,
         local_files_per_upload_request: int,
-        local_file_upload_concurrency: int,
     ):
         # Batch into requests
         requests = []
@@ -125,7 +121,8 @@ class DatasetItemUploader:
             requests.append(request)
 
         progressbar = self._client.tqdm_bar(
-            total=len(requests), desc=f"Uploading {len(items)} items in {len(requests)} batches"
+            total=len(requests),
+            desc=f"Uploading {len(items)} items in {len(requests)} batches",
         )
 
         return make_many_form_data_requests_concurrently(

--- a/nucleus/dataset_item_uploader.py
+++ b/nucleus/dataset_item_uploader.py
@@ -78,7 +78,6 @@ class DatasetItemUploader:
                     self.dataset_id,
                     items=local_items,
                     update=update,
-                    batch_size=batch_size,
                     local_files_per_upload_request=local_files_per_upload_request,
                     local_file_upload_concurrency=local_file_upload_concurrency,
                 )
@@ -112,7 +111,6 @@ class DatasetItemUploader:
         dataset_id: str,
         items: Sequence[DatasetItem],
         update: bool,
-        batch_size: int,
         local_files_per_upload_request: int,
         local_file_upload_concurrency: int,
     ):
@@ -127,7 +125,7 @@ class DatasetItemUploader:
             requests.append(request)
 
         progressbar = self._client.tqdm_bar(
-            total=len(requests), desc="Local file batches"
+            total=len(requests), desc=f"Uploading {len(items)} items in {len(requests)} batches"
         )
 
         return make_many_form_data_requests_concurrently(
@@ -135,7 +133,6 @@ class DatasetItemUploader:
             requests,
             f"dataset/{dataset_id}/append",
             progressbar=progressbar,
-            concurrency=local_file_upload_concurrency,
         )
 
     def _process_append_requests(

--- a/nucleus/model_run.py
+++ b/nucleus/model_run.py
@@ -120,7 +120,6 @@ class ModelRun:
         batch_size: int = 5000,
         remote_files_per_upload_request: int = 20,
         local_files_per_upload_request: int = 10,
-        local_file_upload_concurrency: int = 30,
     ) -> Union[dict, AsyncJob]:
         """
         Uploads model outputs as predictions for a model_run. Returns info about the upload.
@@ -144,8 +143,6 @@ class ModelRun:
                 request. Segmentations have either local or remote files, if you are
                 getting timeouts while uploading segmentations with local files, you
                 should lower this value from its default of 10. The maximum is 10.
-                This is only relevant for asynchronous=False
-            local_file_upload_concurrency: Number of concurrent local file uploads.
                 This is only relevant for asynchronous=False
         :return:
         {
@@ -177,7 +174,6 @@ class ModelRun:
             batch_size=batch_size,
             remote_files_per_upload_request=remote_files_per_upload_request,
             local_files_per_upload_request=local_files_per_upload_request,
-            local_file_upload_concurrency=local_file_upload_concurrency,
         )
 
     def iloc(self, i: int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.19"
+version = "0.14.20"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -776,7 +776,7 @@ def test_non_existent_taxonomy_category_pred_upload_async(model_run: ModelRun):
 
     status = job.status()
     assert status["job_id"] == job.job_id
-    assert status["status"] == "Errored"
+    assert status["status"] == "Errored_Server"
     assert status["job_progress"] == "0.00"
 
 


### PR DESCRIPTION
When trying to run local uploads with large number of items, ie: 1k+ the following error appeared:
`Cannot connect to host api.scale.com:443 ssl:default [nodename nor servname provided, or not known”`

This (to my understanding) was caused by flooding the network with too many simultaneous requests. 

It seems like the Semaphore that was previously implemented to control the `concurrency` was not controlling the POST requests properly. 


[[sc-594516]](https://app.shortcut.com/scaleai/story/594516)
