### PR TITLE
Pytest dataset fixture no teardown

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,8 +31,6 @@ def dataset(CLIENT: "NucleusClient"):
     test_dataset.append(TEST_DATASET_ITEMS)
     yield test_dataset
 
-    CLIENT.delete_dataset(test_dataset.id)
-
 
 @pytest.fixture()
 def model(CLIENT):

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -24,15 +24,11 @@ def module_scope_datasets(CLIENT):
         )
     yield test_datasets
 
-    for test_dataset in test_datasets:
-        CLIENT.delete_dataset(test_dataset.id)
-
 
 @pytest.fixture(scope="function")
 def function_scope_dataset(CLIENT):
     dataset = CLIENT.create_dataset(f"[PyTest] Dataset {get_uuid()}")
     yield dataset
-    CLIENT.delete_dataset(dataset.id)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -100,9 +100,6 @@ def dataset(CLIENT):
 
     yield ds
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
-
 
 @pytest.fixture()
 def scene_category_dataset(CLIENT):
@@ -121,9 +118,6 @@ def scene_category_dataset(CLIENT):
     ds.add_taxonomy(*TEST_SCENE_CATEGORY_TAXONOMY_PAYLOAD)
 
     yield ds
-
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_box_gt_upload(dataset):

--- a/tests/test_autocurate.py
+++ b/tests/test_autocurate.py
@@ -42,8 +42,6 @@ def model_run(CLIENT):
 
     yield run
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
     response = CLIENT.delete_model(model.id)
     assert response == {}
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -48,13 +48,13 @@ from .helpers import (
 def dataset(CLIENT):
     ds = CLIENT.create_dataset(TEST_DATASET_NAME, is_scene=False)
 
-    response = ds.add_taxonomy(
+    ds.add_taxonomy(
         "[Pytest] Category Taxonomy 1",
         "category",
         [f"[Pytest] Category Label ${i}" for i in range((len(TEST_IMG_URLS)))],
     )
 
-    response = ds.add_taxonomy(
+    ds.add_taxonomy(
         "[Pytest] MultiCategory Taxonomy 1",
         "multicategory",
         [

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -65,15 +65,11 @@ def dataset(CLIENT):
 
     yield ds
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
-
 
 @pytest.fixture()
 def dataset_scene(CLIENT):
     ds = CLIENT.create_dataset(TEST_DATASET_NAME, is_scene=True)
     yield ds
-    CLIENT.delete_dataset(ds.id)
 
 
 def make_dataset_items():

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -34,9 +34,6 @@ def dataset(CLIENT):
     assert ERROR_PAYLOAD not in response.json()
     yield ds
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
-
 
 @pytest.mark.integration
 def test_set_continuous_indexing(dataset):

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -110,8 +110,6 @@ def model_run(CLIENT):
 
     yield run
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
     response = CLIENT.delete_model(model.id)
     assert response == {}
 
@@ -140,8 +138,6 @@ def scene_category_model_run(CLIENT):
 
     yield run
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
     response = CLIENT.delete_model(model.id)
     assert response == {}
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -52,17 +52,11 @@ def dataset_scene(CLIENT):
     ds = CLIENT.create_dataset(TEST_DATASET_3D_NAME, is_scene=True)
     yield ds
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
-
 
 @pytest.fixture()
 def dataset_item(CLIENT):
     ds = CLIENT.create_dataset(TEST_DATASET_3D_NAME, is_scene=False)
     yield ds
-
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
 
 
 def test_frame_add_item():

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -14,9 +14,6 @@ def taxonomy_dataset(CLIENT):
     )
     yield ds
 
-    response = CLIENT.delete_dataset(ds.id)
-    assert response == {"message": "Beginning dataset deletion..."}
-
 
 def test_create_taxonomy(taxonomy_dataset):
     response = taxonomy_dataset.add_taxonomy(

--- a/tests/validate/conftest.py
+++ b/tests/validate/conftest.py
@@ -18,8 +18,6 @@ def validate_dataset(CLIENT):
     ds = CLIENT.create_dataset("[Test Model CI] Dataset", is_scene=False)
     yield ds
 
-    CLIENT.delete_dataset(ds.id)
-
 
 @pytest.fixture(scope="module")
 def dataset_items(validate_dataset):


### PR DESCRIPTION
Leaving the teardown to pytest causes race conditions in CircleCI because of multiple workers. We will add a cron to instead clean up datasets this on a daily basis, outside of typical CI windows.