### PR TITLE
Speed up shell and CLI invocation with Nucleus installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.24](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.24) - 2022-10-19
+
+### Fixed
+- Late imports for seldomly used heavy libraries. Sped up CLI invocation and autocomplation.
+  If you had shell completions installed before we recommend removeing them from your .(bash|zsh)rc
+  file and reinstalling with nu install-completions
+
 ## [0.14.23](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.14.23) - 2022-10-17
 
 ### Added

--- a/cli/client.py
+++ b/cli/client.py
@@ -1,14 +1,19 @@
 import functools
-import os
 
-import nucleus
+from rich.console import Console
 
 
 @functools.lru_cache()
 def init_client():
-    api_key = os.environ.get("NUCLEUS_API_KEY", None)
-    if api_key:
-        client = nucleus.NucleusClient(api_key)
-    else:
-        raise RuntimeError("No NUCLEUS_API_KEY set")
-    return client
+    console = Console()
+    with console.status("Initializing client"):
+        import os
+
+        import nucleus
+
+        api_key = os.environ.get("NUCLEUS_API_KEY", None)
+        if api_key:
+            client = nucleus.NucleusClient(api_key)
+        else:
+            raise RuntimeError("No NUCLEUS_API_KEY set")
+        return client

--- a/cli/install_completion.py
+++ b/cli/install_completion.py
@@ -1,33 +1,48 @@
 import os
 import shutil
+import subprocess
 
 import click
 from shellingham import detect_shell
+
+
+def generate_completions(shell, completion_path):
+    command = f"_NU_COMPLETE={shell}_source nu > {completion_path}"
+    subprocess.run(command, shell=True)
+    click.echo(f"Generated completions for {shell}: {completion_path}")
 
 
 @click.command("install-completion")
 def install_completion():
     """Install shell completion script to your rc file"""
     shell, _ = detect_shell()
+    os.makedirs("~/.config", exist_ok=True)
+    append_to_file = None
     if shell == "zsh":
         rc_path = "~/.zshrc"
-        append_to_file = 'eval "$(_NU_COMPLETE=zsh_source nu)"'
+        completion_path = "~/.config/nu-cli-completions.zsh"
+        append_to_file = f". {completion_path}"
     elif shell == "bash":
         rc_path = "~/.bashrc"
-        append_to_file = 'eval "$(_NU_COMPLETE=bash_source nu)"'
+        completion_path = "~/.config/nu-cli-completions.bash"
+        append_to_file = f". {completion_path}"
     elif shell == "fish":
         rc_path = "~/.config/fish/completions/foo-bar.fish"
-        append_to_file = "eval (env _NU_COMPLETE=fish_source nu)"
+        completion_path = "~/.config/fish/completions/nu.fish"
     else:
         raise RuntimeError(f"Unsupported shell {shell} for completions")
 
-    rc_path_expanded = os.path.expanduser(rc_path)
-    rc_bak = f"{rc_path_expanded}.bak"
-    shutil.copy(rc_path_expanded, rc_bak)
-    click.echo(f"Backed up {rc_path} to {rc_bak}")
-    with open(rc_path_expanded, mode="a") as rc_file:
-        rc_file.write("\n")
-        rc_file.write("# Shell completion for nu\n")
-        rc_file.write(append_to_file)
+    generate_completions(shell, completion_path)
+
+    if append_to_file is not None:
+        rc_path_expanded = os.path.expanduser(rc_path)
+        rc_bak = f"{rc_path_expanded}.bak"
+        shutil.copy(rc_path_expanded, rc_bak)
+        click.echo(f"Backed up {rc_path} to {rc_bak}")
+        with open(rc_path_expanded, mode="a") as rc_file:
+            rc_file.write("\n")
+            rc_file.write("# Shell completion for nu\n")
+            rc_file.write(append_to_file)
+
     click.echo(f"Completion script added to {rc_path}")
     click.echo(f"Don't forget to `source {rc_path}")

--- a/cli/models.py
+++ b/cli/models.py
@@ -1,5 +1,4 @@
 import click
-import questionary
 from rich.console import Console
 from rich.pretty import pretty_repr
 from rich.table import Column, Table
@@ -35,6 +34,8 @@ def json_string_to_string(s: str) -> str:
 
 @models.command("calculate-metrics")
 def metrics():
+    import questionary
+
     client = init_client()
     models = client.models
     prompt_to_id = {f"{m.id}: {m.name}": m.id for m in models}

--- a/cli/slices.py
+++ b/cli/slices.py
@@ -1,14 +1,10 @@
 import click
 from rich.console import Console
-from rich.live import Live
-from rich.spinner import Spinner
 from rich.table import Column, Table
-from rich.tree import Tree
 
 from cli.client import init_client
 from cli.helpers.nucleus_url import nucleus_url
 from cli.helpers.web_helper import launch_web_or_invoke
-from nucleus import NucleusAPIError
 
 
 @click.group("slices", invoke_without_command=True)

--- a/cli/tests.py
+++ b/cli/tests.py
@@ -11,11 +11,7 @@ from cli.helpers.nucleus_url import nucleus_url
 from cli.helpers.web_helper import launch_web_or_invoke
 
 if TYPE_CHECKING:
-    from nucleus.validate import (
-        AvailableEvalFunctions,
-        ScenarioTestMetric,
-        ThresholdComparison,
-    )
+    from nucleus.validate import AvailableEvalFunctions, ScenarioTestMetric
 
 
 @click.group("tests", invoke_without_command=True)

--- a/cli/tests.py
+++ b/cli/tests.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import click
 from rich.console import Console
 from rich.live import Live
@@ -7,12 +9,13 @@ from rich.tree import Tree
 from cli.client import init_client
 from cli.helpers.nucleus_url import nucleus_url
 from cli.helpers.web_helper import launch_web_or_invoke
-from nucleus import NucleusAPIError
-from nucleus.validate import (
-    AvailableEvalFunctions,
-    ScenarioTestMetric,
-    ThresholdComparison,
-)
+
+if TYPE_CHECKING:
+    from nucleus.validate import (
+        AvailableEvalFunctions,
+        ScenarioTestMetric,
+        ThresholdComparison,
+    )
 
 
 @click.group("tests", invoke_without_command=True)
@@ -47,8 +50,10 @@ def list_tests():
 
 
 def format_criterion(
-    criterion: ScenarioTestMetric, eval_functions: AvailableEvalFunctions
+    criterion: "ScenarioTestMetric", eval_functions: "AvailableEvalFunctions"
 ):
+    from nucleus.validate import ThresholdComparison
+
     op_map = {
         ThresholdComparison.GREATER_THAN: ">",
         ThresholdComparison.GREATER_THAN_EQUAL_TO: ">=",
@@ -95,6 +100,8 @@ def describe_test(scenario_test_id, all):
 
 
 def build_scenario_test_info_tree(client, scenario_test, tree):
+    from nucleus import NucleusAPIError
+
     try:
         slc = client.get_slice(scenario_test.slice_id)
         info_branch = tree.add(":mag: Details")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 import os
 import sys
 
+import pkg_resources
+
 sys.path.insert(0, os.path.abspath("../../"))
 
 
@@ -22,10 +24,9 @@ project = "Nucleus"
 copyright = "2021, Scale"
 author = "Scale"
 
-# The full version, including alpha/beta/rc tags
-from nucleus import __version__  # noqa: E402
 
-release = "v" + str(__version__)
+# The full version, including alpha/beta/rc tags
+release = "v" + str(pkg_resources.get_distribution("scale-nucleus").version)
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -44,11 +44,9 @@ import os
 import warnings
 from typing import Any, Dict, List, Optional, Sequence, Union
 
-import pkg_resources
 import pydantic
 import requests
 import tqdm
-import tqdm.notebook as tqdm_notebook
 
 from nucleus.url_utils import sanitize_string_args
 
@@ -150,9 +148,6 @@ from .validate import Validate
 # pylint: disable=C0302
 
 
-__version__ = pkg_resources.get_distribution("scale-nucleus").version
-
-
 class NucleusClient:
     """Client to interact with the Nucleus API via Python SDK.
 
@@ -180,6 +175,8 @@ class NucleusClient:
             self.endpoint = endpoint
         self._use_notebook = use_notebook
         if use_notebook:
+            import tqdm.notebook as tqdm_notebook
+
             self.tqdm_bar = tqdm_notebook.tqdm
         self._connection = Connection(self.api_key, self.endpoint)
         self.validate = Validate(self.api_key, self.endpoint)

--- a/nucleus/errors.py
+++ b/nucleus/errors.py
@@ -1,9 +1,3 @@
-import pkg_resources
-
-nucleus_client_version = pkg_resources.get_distribution(
-    "scale-nucleus"
-).version
-
 INFRA_FLAKE_MESSAGES = [
     "downstream duration timeout",
     "upstream connect error or disconnect/reset before headers. reset reason: local reset",
@@ -40,6 +34,12 @@ class NucleusAPIError(Exception):
     def __init__(
         self, endpoint, command, requests_response=None, aiohttp_response=None
     ):
+        import pkg_resources
+
+        nucleus_client_version = pkg_resources.get_distribution(
+            "scale-nucleus"
+        ).version
+
         self.message = f"Your client is on version {nucleus_client_version}. If you have not recently done so, please make sure you have updated to the latest version of the client by running pip install --upgrade scale-nucleus\n"
         if requests_response is not None:
             self.status_code = requests_response.status_code

--- a/nucleus/metrics/categorization_metrics.py
+++ b/nucleus/metrics/categorization_metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union

--- a/nucleus/metrics/categorization_metrics.py
+++ b/nucleus/metrics/categorization_metrics.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union

--- a/nucleus/metrics/cuboid_utils.py
+++ b/nucleus/metrics/cuboid_utils.py
@@ -99,15 +99,15 @@ def process_dataitem(dataitem):
 
 
 def compute_outer_iou(
-    xyz_0: np.ndarray,
-    wlh_0: np.ndarray,
-    yaw_0: np.ndarray,
-    xyz_1: np.ndarray,
-    wlh_1: np.ndarray,
-    yaw_1: np.ndarray,
+    xyz_0: "np.ndarray",
+    wlh_0: "np.ndarray",
+    yaw_0: "np.ndarray",
+    xyz_1: "np.ndarray",
+    wlh_1: "np.ndarray",
+    yaw_1: "np.ndarray",
     scale_convention: bool = True,
     distance_threshold=25,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple["np.ndarray", "np.ndarray"]:
     """
     Computes outer 3D and 2D IoU
     :param xyz_0: (n, 3)
@@ -173,13 +173,13 @@ def compute_outer_iou(
 
 
 def get_batch_cuboid_corners(
-    xyz: np.ndarray,
-    wlh: np.ndarray,
-    yaw: np.ndarray,
-    pitch: np.ndarray = None,
-    roll: np.ndarray = None,
+    xyz: "np.ndarray",
+    wlh: "np.ndarray",
+    yaw: "np.ndarray",
+    pitch: "np.ndarray" = None,
+    roll: "np.ndarray" = None,
     scale_convention: bool = True,
-) -> np.ndarray:
+) -> "np.ndarray":
     """
     Vectorized batch version of get_cuboid_corners
     :param xyz: (n, 3)
@@ -211,8 +211,8 @@ def get_batch_cuboid_corners(
 
 
 def get_batch_rotation_matrices(
-    yaw: np.ndarray, pitch: np.ndarray = None, roll: np.ndarray = None
-) -> np.ndarray:
+    yaw: "np.ndarray", pitch: "np.ndarray" = None, roll: "np.ndarray" = None
+) -> "np.ndarray":
     if pitch is None:
         pitch = np.zeros_like(yaw)
     if roll is None:
@@ -238,12 +238,12 @@ def get_batch_rotation_matrices(
 
 
 def associate_cuboids_on_iou(
-    xyz_0: np.ndarray,
-    wlh_0: np.ndarray,
-    yaw_0: np.ndarray,
-    xyz_1: np.ndarray,
-    wlh_1: np.ndarray,
-    yaw_1: np.ndarray,
+    xyz_0: "np.ndarray",
+    wlh_0: "np.ndarray",
+    yaw_0: "np.ndarray",
+    xyz_1: "np.ndarray",
+    wlh_1: "np.ndarray",
+    yaw_1: "np.ndarray",
     threshold_in_overlap_ratio: float = 0.1,
 ) -> List[Tuple[int, int]]:
     if xyz_0.shape[0] < 1 or xyz_1.shape[0] < 1:
@@ -322,7 +322,7 @@ def detection_iou(
     prediction: List[CuboidPrediction],
     groundtruth: List[CuboidAnnotation],
     threshold_in_overlap_ratio: float,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple["np.ndarray", "np.ndarray"]:
     """
     Calculates the 2D IOU and 3D IOU overlap between predictions and groundtruth.
     Uses linear sum assignment to associate cuboids.

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 from functools import wraps
@@ -24,9 +26,13 @@ def polygon_annotation_to_shape(
     annotation: BoxOrPolygonAnnotation,
 ) -> "Polygon":
     try:
-        from shapely.geometry import Polygon
+        from shapely.geometry import (  # pylint: disable=redefined-outer-name
+            Polygon,
+        )
     except (ModuleNotFoundError, OSError):
-        from ..package_not_installed import PackageNotInstalled
+        from ..package_not_installed import (  # pylint: disable=redefined-outer-name
+            PackageNotInstalled,
+        )
 
         Polygon = PackageNotInstalled
     if isinstance(annotation, BoxAnnotation):

--- a/nucleus/metrics/polygon_utils.py
+++ b/nucleus/metrics/polygon_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import sys
 from functools import wraps
@@ -57,7 +55,7 @@ def _iou(annotation: "Polygon", prediction: "Polygon") -> float:
 
 def _iou_matrix(
     annotations: List["Polygon"], predictions: List["Polygon"]
-) -> np.ndarray:
+) -> "np.ndarray":
     import numpy as np
 
     iou_matrix = np.empty((len(predictions), len(annotations)))
@@ -71,7 +69,7 @@ def _iou_assignments_for_same_reference_id(
     annotations: List[BoxOrPolygonAnnotation],
     predictions: List[BoxOrPolygonPrediction],
     iou_threshold: float,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple["np.ndarray", "np.ndarray", "np.ndarray"]:
     # NOTE: Late imports to speed up CLI invocation
     import numpy as np
     from scipy.optimize import linear_sum_assignment
@@ -205,7 +203,7 @@ def iou_assignments(
     annotations: List[BoxOrPolygonAnnotation],
     predictions: List[BoxOrPolygonPrediction],
     iou_threshold: float,
-) -> np.ndarray:
+) -> "np.ndarray":
     """Matches annotations and predictions based on linear sum cost and returns the
     intersection-over-union values of the matched annotation-prediction pairs, subject
     to the specified IoU threshold. Note that annotations and predictions from
@@ -239,7 +237,7 @@ def get_true_false_positives_confidences(
     annotations: List[BoxOrPolygonAnnotation],
     predictions: List[BoxOrPolygonPrediction],
     iou_threshold: float,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple["np.ndarray", "np.ndarray"]:
     """Matches annotations and predictions based on linear sum cost and returns the
     intersection-over-union values of the matched annotation-prediction pairs, subject
     to the specified IoU threshold. Note that annotations and predictions from

--- a/nucleus/metrics/segmentation_loader.py
+++ b/nucleus/metrics/segmentation_loader.py
@@ -1,17 +1,18 @@
 import abc
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
-import numpy as np
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class SegmentationMaskLoader(abc.ABC):
     @abc.abstractmethod
-    def fetch(self, url: str) -> np.ndarray:
+    def fetch(self, url: str) -> "np.ndarray":
         pass
 
 
 class DummyLoader(SegmentationMaskLoader):
-    def fetch(self, url: str) -> np.ndarray:
+    def fetch(self, url: str) -> "np.ndarray":
         raise NotImplementedError(
             "This dummy loader has to be replaced with an actual implementation of an image loader"
         )
@@ -22,7 +23,7 @@ class InMemoryLoader(SegmentationMaskLoader):
     from a filesystem.
     """
 
-    def __init__(self, url_to_array: Dict[str, np.ndarray]):
+    def __init__(self, url_to_array: Dict[str, "np.ndarray"]):
         self.url_to_array = url_to_array
 
     def fetch(self, url: str):

--- a/nucleus/metrics/segmentation_metrics.py
+++ b/nucleus/metrics/segmentation_metrics.py
@@ -114,8 +114,8 @@ class SegmentationMaskMetric(Metric):
     @abc.abstractmethod
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ):
@@ -128,7 +128,7 @@ class SegmentationMaskMetric(Metric):
         prediction,
         prediction_img,
         iou_threshold,
-    ) -> Tuple[np.ndarray, Set[int]]:
+    ) -> Tuple["np.ndarray", Set[int]]:
         """This calculates a confusion matrix with ground_truth_index X predicted_index summary
 
         Notes:
@@ -270,8 +270,8 @@ class SegmentationIOU(SegmentationMaskMetric):
 
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ) -> ScalarResult:
@@ -341,8 +341,8 @@ class SegmentationPrecision(SegmentationMaskMetric):
 
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ) -> ScalarResult:
@@ -416,8 +416,8 @@ class SegmentationRecall(SegmentationMaskMetric):
 
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ) -> ScalarResult:
@@ -520,8 +520,8 @@ class SegmentationMAP(SegmentationMaskMetric):
 
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ) -> ScalarResult:
@@ -627,8 +627,8 @@ class SegmentationFWAVACC(SegmentationMaskMetric):
 
     def _metric_impl(
         self,
-        annotation_img: np.ndarray,
-        prediction_img: np.ndarray,
+        annotation_img: "np.ndarray",
+        prediction_img: "np.ndarray",
         annotation: SegmentationAnnotation,
         prediction: SegmentationPrediction,
     ) -> ScalarResult:

--- a/nucleus/metrics/segmentation_to_poly_metrics.py
+++ b/nucleus/metrics/segmentation_to_poly_metrics.py
@@ -164,9 +164,9 @@ class SegmentationMaskToPolyMetric(Metric):
     def call_segmentation_metric(
         self,
         annotations: AnnotationList,
-        ann_img: np.ndarray,
+        ann_img: "np.ndarray",
         predictions: PredictionList,
-        pred_img: np.ndarray,
+        pred_img: "np.ndarray",
     ):
         metric = self.configure_metric()
         metric.loader = InMemoryLoader(

--- a/nucleus/metrics/segmentation_utils.py
+++ b/nucleus/metrics/segmentation_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Sequence, Tuple, Union

--- a/nucleus/metrics/segmentation_utils.py
+++ b/nucleus/metrics/segmentation_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Sequence, Tuple, Union
@@ -11,21 +13,20 @@ from nucleus.package_not_installed import (  # pylint: disable=ungrouped-imports
 
 FALSE_POSITIVES = "__non_max_false_positive"
 
-try:
-    from shapely import geometry
-except (ModuleNotFoundError, OSError):
-    geometry = PackageNotInstalled
-
 
 if TYPE_CHECKING:
     import numpy as np
 
 
-def instance_mask_to_polys(instance_mask: np.ndarray, background_code=None):
+def instance_mask_to_polys(instance_mask: "np.ndarray", background_code=None):
+    import numpy as np
+
     try:
         from rasterio import features
+        from shapely import geometry
     except (ModuleNotFoundError, OSError):
-        PackageNotInstalled()
+        geometry = PackageNotInstalled
+        features = PackageNotInstalled
     mask_values = []
     all_polygons = []
     not_background_mask = (
@@ -87,8 +88,8 @@ def max_iou_match_from_confusion(confusion):
 
 
 def fast_confusion_matrix(
-    label_true: np.ndarray, label_pred: np.ndarray, n_class: int
-) -> np.ndarray:
+    label_true: "np.ndarray", label_pred: "np.ndarray", n_class: int
+) -> "np.ndarray":
     """Calculates confusion matrix - fast!
 
     Outputs a confusion matrix where each row is GT confusion and column is prediction confusion
@@ -109,7 +110,7 @@ def fast_confusion_matrix(
     return hist
 
 
-def non_max_suppress_confusion(confusion: np.ndarray, iou_threshold):
+def non_max_suppress_confusion(confusion: "np.ndarray", iou_threshold):
     """Uses linear sum assignment to find biggest pixel-wise IOU match. Secondary matches are moved to last column
     as false positives (since they are outside of instance boundaries).
 
@@ -173,7 +174,7 @@ def non_max_suppress_confusion(confusion: np.ndarray, iou_threshold):
 
 def rasterize_polygons_to_segmentation_mask(
     annotations: Sequence[BoxOrPolygonAnnotation], shape: Tuple
-) -> Tuple[np.ndarray, List[Segment]]:
+) -> Tuple["np.ndarray", List[Segment]]:
     try:
         from rasterio import features
     except (ModuleNotFoundError, OSError):

--- a/nucleus/metrics/segmentation_utils.py
+++ b/nucleus/metrics/segmentation_utils.py
@@ -1,9 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import List, Sequence, Tuple, Union
-
-import numpy as np
-from scipy.optimize import linear_sum_assignment
+from typing import TYPE_CHECKING, List, Sequence, Tuple, Union
 
 from nucleus import Point, PolygonPrediction, Segment
 from nucleus.metrics.custom_types import BoxOrPolygonAnnotation
@@ -20,13 +17,15 @@ except (ModuleNotFoundError, OSError):
     geometry = PackageNotInstalled
 
 
-try:
-    from rasterio import features
-except (ModuleNotFoundError, OSError):
-    rasterio = PackageNotInstalled
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def instance_mask_to_polys(instance_mask: np.ndarray, background_code=None):
+    try:
+        from rasterio import features
+    except (ModuleNotFoundError, OSError):
+        PackageNotInstalled()
     mask_values = []
     all_polygons = []
     not_background_mask = (
@@ -67,6 +66,9 @@ def max_iou_match_from_confusion(confusion):
     Returns:
         iou_matrix with same dims as confusion and 1-d best match rows, 1-d best match cols
     """
+    import numpy as np
+    from scipy.optimize import linear_sum_assignment
+
     iou = np.zeros(confusion.shape, dtype=np.float)
     with np.errstate(divide="ignore", invalid="ignore"):
         for i in range(confusion.shape[0]):
@@ -97,6 +99,8 @@ def fast_confusion_matrix(
                [0, 1, 0, 0],
                [0, 1, 0, 0]])
     """
+    import numpy as np
+
     mask = (label_true >= 0) & (label_true < n_class)
     hist = np.bincount(
         n_class * label_true[mask].astype(int) + label_pred[mask],
@@ -120,6 +124,8 @@ def non_max_suppress_confusion(confusion: np.ndarray, iou_threshold):
         positives
 
     """
+    import numpy as np
+
     original_count = confusion.sum()
     iou, max_iou_row, max_iou_col = max_iou_match_from_confusion(confusion)
     # Prepare the new confusion with +1 added to the shape
@@ -168,6 +174,10 @@ def non_max_suppress_confusion(confusion: np.ndarray, iou_threshold):
 def rasterize_polygons_to_segmentation_mask(
     annotations: Sequence[BoxOrPolygonAnnotation], shape: Tuple
 ) -> Tuple[np.ndarray, List[Segment]]:
+    try:
+        from rasterio import features
+    except (ModuleNotFoundError, OSError):
+        PackageNotInstalled()
     polys = [polygon_annotation_to_shape(a) for a in annotations]
     segments = [
         Segment(ann.label, index=idx + 1, metadata=ann.metadata)
@@ -188,6 +198,8 @@ def rasterize_polygons_to_segmentation_mask(
 
 
 def convert_to_instance_seg_confusion(confusion, annotation, prediction):
+    import numpy as np
+
     pred_index_to_label = {s.index: s.label for s in prediction.annotations}
 
     gt_label_to_old_indexes = defaultdict(set)
@@ -263,6 +275,8 @@ def convert_to_instance_seg_confusion(confusion, annotation, prediction):
 
 
 def setup_iou_thresholds(iou_thresholds: Union[Sequence[float], str] = "coco"):
+    import numpy as np
+
     supported_iou_setups = {"coco"}
     if isinstance(iou_thresholds, (list, np.ndarray)):
         return np.array(iou_thresholds, np.float_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.14.23"
+version = "0.14.24"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ python = ">=3.6.2,<4.0"
 requests = "^2.23.0"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
-future-annotations= { version = "^1.0.0", python = "^3.6.1, <3.7" }
 aiohttp = "^3.7.4"
 nest-asyncio = "^1.5.1"
 pydantic = "^1.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ python = ">=3.6.2,<4.0"
 requests = "^2.23.0"
 tqdm = "^4.41.0"
 dataclasses = { version = "^0.7", python = "^3.6.1, <3.7" }
+future-annotations= { version = "^1.0.0", python = "^3.6.1, <3.7" }
 aiohttp = "^3.7.4"
 nest-asyncio = "^1.5.1"
 pydantic = "^1.8.2"


### PR DESCRIPTION
Managing imports to late import stuff that is not necessary for most users.
- np, sklearn and shapely on the metrics side (which nobody but our internal services use)
- tqdm notebook is now only loaded in notebooks.
- Shell completion script is now generated once and sourced -> this speeds up shell init considerably and autocompletion

Timing:
```
pipx install tuna
poetry run python -X importtime cli/nu.py 2>tuna.log
tuna tuna.log
```
# Before
<img width="701" alt="image" src="https://user-images.githubusercontent.com/28716377/196276372-c795e822-7fc1-4c22-8894-ba5a1168bbcf.png">

# After

<img width="693" alt="image" src="https://user-images.githubusercontent.com/28716377/196276080-c40614a7-2734-42b4-b6a8-ec77397b51d5.png">
