### PR TITLE
fix typo in launch call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.2) - 2023-02-10
+
+### Changed
+- Fix `client.create_launch_model_from_dir(args)` method
+
 ## [0.15.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.1) - 2023-01-16
 
 ### Changed

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -740,7 +740,7 @@ class NucleusClient:
             **bundle_from_dir_args,
         }
 
-        bundle = launch_client.create_model_bundle_from_dir(**kwargs)
+        bundle = launch_client.create_model_bundle_from_dirs(**kwargs)
 
         return self.create_model(
             name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.15.1"
+version = "0.15.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
fix typo in launch call

should be create_model_bundle_from_dirs not create_model_bundle_from_dir based on documentation here
https://crispy-fiesta-68ad3f76.pages.github.io/api/launch_internal/index.html#launch_internal.InternalLaunchClient.create_model_bundle_from_dirs