### PR TITLE
Limit async append jobs to 1000 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.3) - 2023-02-15
+
+### Changed
+- Limit `dataset.append` async jobs to 1000 items 
+
 ## [0.15.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.2) - 2023-02-10
 
 ### Changed

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -614,6 +614,10 @@ class Dataset:
         assert (
             batch_size is None or batch_size < 30
         ), "Please specify a batch size smaller than 30 to avoid timeouts."
+
+        if asynchronous:
+            assert len(items) <= 1000, "Please limit the number of items to 1000 per asynchronous job."
+
         dataset_items = [
             item for item in items if isinstance(item, DatasetItem)
         ]

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -616,7 +616,9 @@ class Dataset:
         ), "Please specify a batch size smaller than 30 to avoid timeouts."
 
         if asynchronous:
-            assert len(items) <= 1000, "Please limit the number of items to 1000 per asynchronous job."
+            assert (
+                len(items) <= 1000
+            ), "Please limit the number of items to 1000 per asynchronous job."
 
         dataset_items = [
             item for item in items if isinstance(item, DatasetItem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.15.2"
+version = "0.15.3"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
The server does not batch incoming requests.
As such, we limit each job request to have at most 1000 items