### PR TITLE
Fix Nucleus export_predictions_generator not returning confidences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.10](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.10) - 2023-07-20
+
+### Added
+- Fix `slice.export_predictions(args)` and `slice.export_predictions_generator(args)` methods to return `Predictions` instead of `Annotations`
+
 ## [0.15.9](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.9) - 2023-06-26
 
 ### Added

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -239,33 +239,62 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
         if row.get(SEGMENTATION_TYPE) is not None:
             segmentation = row[SEGMENTATION_TYPE]
             segmentation[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[SEGMENTATION_TYPE] = SegmentationAnnotation.from_json(
-                segmentation
-            )
+            if not has_predictions:
+                annotations[SEGMENTATION_TYPE] = SegmentationAnnotation.from_json(
+                    segmentation
+                )
+            else:
+                annotations[SEGMENTATION_TYPE] = SegmentationPrediction.from_json(
+                    segmentation
+                )
         for polygon in row[POLYGON_TYPE]:
             polygon[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[POLYGON_TYPE].append(
-                PolygonAnnotation.from_json(polygon)
-            )
+            if not has_predictions:
+                annotations[POLYGON_TYPE].append(
+                    PolygonAnnotation.from_json(polygon)
+                )
+            else:
+                annotations[POLYGON_TYPE].append(
+                    PolygonPrediction.from_json(polygon)
+                )
         for line in row[LINE_TYPE]:
             line[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[LINE_TYPE].append(LineAnnotation.from_json(line))
+            if not has_predictions:
+                annotations[LINE_TYPE].append(LineAnnotation.from_json(line))
+            else:
+                annotations[LINE_TYPE].append(LinePrediction.from_json(line))
         for keypoints in row[KEYPOINTS_TYPE]:
             keypoints[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[KEYPOINTS_TYPE].append(
-                KeypointsAnnotation.from_json(keypoints)
-            )
+            if not has_predictions:
+                annotations[KEYPOINTS_TYPE].append(
+                    KeypointsAnnotation.from_json(keypoints)
+                )
+            else:
+                annotations[KEYPOINTS_TYPE].append(
+                    KeypointsPrediction.from_json(keypoints)
+                )
         for box in row[BOX_TYPE]:
             box[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[BOX_TYPE].append(BoxAnnotation.from_json(box))
+            if not has_predictions:
+                annotations[BOX_TYPE].append(BoxAnnotation.from_json(box))
+            else:
+                annotations[BOX_TYPE].append(BoxPrediction.from_json(box))
         for cuboid in row[CUBOID_TYPE]:
             cuboid[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[CUBOID_TYPE].append(CuboidAnnotation.from_json(cuboid))
+            if not has_predictions:
+                annotations[CUBOID_TYPE].append(CuboidAnnotation.from_json(cuboid))
+            else:
+                annotations[CUBOID_TYPE].append(CuboidPrediction.from_json(cuboid))
         for category in row[CATEGORY_TYPE]:
             category[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
-            annotations[CATEGORY_TYPE].append(
-                CategoryAnnotation.from_json(category)
-            )
+            if not has_predictions:
+                annotations[CATEGORY_TYPE].append(
+                    CategoryAnnotation.from_json(category)
+                )
+            else:
+                annotations[CATEGORY_TYPE].append(
+                    CategoryPrediction.from_json(category)
+                )
         for multicategory in row[MULTICATEGORY_TYPE]:
             multicategory[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             annotations[MULTICATEGORY_TYPE].append(

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -220,6 +220,7 @@ def format_scale_task_info_response(response: dict) -> Union[Dict, List[Dict]]:
             ret.append(row)
     return ret
 
+
 # pylint: disable=too-many-branches
 def convert_export_payload(api_payload, has_predictions: bool = False):
     """Helper function to convert raw JSON to API objects

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -240,13 +240,13 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
             segmentation = row[SEGMENTATION_TYPE]
             segmentation[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             if not has_predictions:
-                annotations[SEGMENTATION_TYPE] = SegmentationAnnotation.from_json(
-                    segmentation
-                )
+                annotations[
+                    SEGMENTATION_TYPE
+                ] = SegmentationAnnotation.from_json(segmentation)
             else:
-                annotations[SEGMENTATION_TYPE] = SegmentationPrediction.from_json(
-                    segmentation
-                )
+                annotations[
+                    SEGMENTATION_TYPE
+                ] = SegmentationPrediction.from_json(segmentation)
         for polygon in row[POLYGON_TYPE]:
             polygon[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             if not has_predictions:
@@ -282,9 +282,13 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
         for cuboid in row[CUBOID_TYPE]:
             cuboid[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             if not has_predictions:
-                annotations[CUBOID_TYPE].append(CuboidAnnotation.from_json(cuboid))
+                annotations[CUBOID_TYPE].append(
+                    CuboidAnnotation.from_json(cuboid)
+                )
             else:
-                annotations[CUBOID_TYPE].append(CuboidPrediction.from_json(cuboid))
+                annotations[CUBOID_TYPE].append(
+                    CuboidPrediction.from_json(cuboid)
+                )
         for category in row[CATEGORY_TYPE]:
             category[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
             if not has_predictions:

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -220,7 +220,7 @@ def format_scale_task_info_response(response: dict) -> Union[Dict, List[Dict]]:
             ret.append(row)
     return ret
 
-
+# pylint: disable=too-many-branches
 def convert_export_payload(api_payload, has_predictions: bool = False):
     """Helper function to convert raw JSON to API objects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.15.9"
+version = "0.15.10"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_autocurate.py
+++ b/tests/test_autocurate.py
@@ -43,7 +43,8 @@ def model_run(CLIENT):
     yield run
 
     response = CLIENT.delete_model(model.id)
-    assert response == {}
+    assert "msg" in response
+    assert response["msg"] == "Model deletion running in an async job"
 
 
 # @pytest.mark.integration

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -591,7 +591,6 @@ def test_dataset_get_image_indexing_status(CLIENT):
     assert "object_count" not in resp
 
 
-
 @pytest.mark.integration
 def test_dataset_get_object_indexing_status(CLIENT):
     dataset = Dataset(DATASET_WITH_EMBEDDINGS, CLIENT)
@@ -599,7 +598,6 @@ def test_dataset_get_object_indexing_status(CLIENT):
     assert resp["embedding_count"] == 422
     assert resp["object_count"] == 423
     assert "image_count" not in resp
-
 
 
 @pytest.mark.integration

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -589,9 +589,7 @@ def test_dataset_get_image_indexing_status(CLIENT):
     assert resp["embedding_count"] == 170
     assert resp["image_count"] == 170
     assert "object_count" not in resp
-    assert round(resp["percent_indexed"], 2) == round(
-        resp["image_count"] / resp["embedding_count"], 2
-    )
+
 
 
 @pytest.mark.integration
@@ -601,9 +599,7 @@ def test_dataset_get_object_indexing_status(CLIENT):
     assert resp["embedding_count"] == 422
     assert resp["object_count"] == 423
     assert "image_count" not in resp
-    assert round(resp["percent_indexed"], 2) == round(
-        resp["object_count"] / resp["embedding_count"], 2
-    )
+
 
 
 @pytest.mark.integration

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -78,6 +78,9 @@ def test_model_creation_and_listing(CLIENT, dataset):
 
     # Delete the model
     CLIENT.delete_model(model.id)
+    time.sleep(
+        30
+    )  # model deletion runs async TODO: do a correct job await here instead of sleep
     ms = CLIENT.models
 
     assert model not in ms

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -111,7 +111,8 @@ def model_run(CLIENT):
     yield run
 
     response = CLIENT.delete_model(model.id)
-    assert response == {}
+    assert "msg" in response
+    assert response["msg"] == "Model deletion running in an async job"
 
 
 @pytest.fixture()
@@ -139,7 +140,8 @@ def scene_category_model_run(CLIENT):
     yield run
 
     response = CLIENT.delete_model(model.id)
-    assert response == {}
+    assert "msg" in response
+    assert response["msg"] == "Model deletion running in an async job"
 
 
 def test_box_pred_upload(model_run):

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -92,7 +92,9 @@ def test_create_mp_with_tracks(CLIENT, dataset_scene):
     ).issubset(expected_track_reference_ids)
 
     # Cleanup
-    assert CLIENT.delete_model(model.id) == {}
+    response = CLIENT.delete_model(model.id) == {}
+    assert "msg" in response
+    assert response["msg"] == "Model deletion running in an async job"
     dataset_scene.delete_tracks(expected_track_reference_ids)
 
 

--- a/tests/validate/test_scenario_test.py
+++ b/tests/validate/test_scenario_test.py
@@ -189,7 +189,9 @@ def test_scenario_test_get_tracks(
 
     # Clean
     CLIENT.validate.delete_scenario_test(scenario_test.id)
-    assert CLIENT.delete_model(model.id) == {}
+    response = CLIENT.delete_model(model.id)
+    assert "msg" in response
+    assert response["msg"] == "Model deletion running in an async job"
 
 
 def test_no_criteria_raises_error(CLIENT, test_slice, annotations):


### PR DESCRIPTION
ix Nucleus export_predictions_generator not returning confidences - see https://www.google.com/url?q=https://scaleapi.slack.com/archives/C01PGG898J1/p1686940016031259&sa=D&source=docs&ust=1689803496342391&usg=AOvVaw3244pEsQvb7D1x-ue7ICew for context

`scaleapi` PR that also needs to be merged: https://github.com/scaleapi/scaleapi/pull/63564

Ticket: https://scale.atlassian.net/browse/FEDENG-4207