### PR TITLE
add raw export for object slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.11](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.11) - 2023-09-15
+
+### Added
+- Added `slice.export_raw_json()` functionality to support raw export of object slices (annotations, predictions, item and scene level data). Currently does not support image slices. 
+
+
 ## [0.15.10](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.15.10) - 2023-07-20
 
 ### Added

--- a/nucleus/slice.py
+++ b/nucleus/slice.py
@@ -11,6 +11,7 @@ from nucleus.async_job import AsyncJob
 from nucleus.constants import EXPORT_FOR_TRAINING_KEY, EXPORTED_ROWS, ITEMS_KEY
 from nucleus.dataset_item import DatasetItem
 from nucleus.errors import NucleusAPIError
+from nucleus.prediction import Prediction
 from nucleus.prediction import from_json as prediction_from_json
 from nucleus.scene import Scene
 from nucleus.utils import (
@@ -457,6 +458,34 @@ class Slice:
             requests_command=requests.get,
         )
         return convert_export_payload(api_payload[EXPORTED_ROWS], True)
+
+    def export_raw_json(
+        self
+    ) -> List[Union[DatasetItem, Annotation, Prediction, Scene]]:
+        """TODO
+
+        Returns:
+            List where each element is a dict containing the DatasetItem
+            and all of its associated Predictions, grouped by type (e.g. box).
+            ::
+
+                List[{
+                    "item": DatasetItem,
+                    "predictions": {
+                        "box": List[BoxAnnotation],
+                        "polygon": List[PolygonAnnotation],
+                        "cuboid": List[CuboidAnnotation],
+                        "segmentation": List[SegmentationAnnotation],
+                        "category": List[CategoryAnnotation],
+                    }
+                }]
+        """
+        api_payload = self._client.make_request(
+            payload=None,
+            route=f"slice/{self.id}/export_raw_json",
+            requests_command=requests.get,
+        )
+        return api_payload
 
     def export_predictions_generator(
         self, model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.15.10"
+version = "0.15.11"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Can export json summaries of object slices containing predictions, annotations, item and scene level data per object in a slice.