### PR TITLE
allow for concurrent task fetches

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
 import datetime
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pydantic
 import requests
@@ -70,6 +70,7 @@ from .annotation import (
     SegmentationAnnotation,
 )
 from .async_job import AsyncJob, EmbeddingsExportJob
+from .async_utils import make_multiple_requests_concurrently
 from .camera_params import CameraParams
 from .connection import Connection
 from .constants import (
@@ -1062,6 +1063,50 @@ class NucleusClient:
             return [LidarPoint.from_json(pt) for pt in points]
 
         return [Point3D.from_json(pt) for pt in points]
+
+    def download_pointcloud_tasks(
+        self, task_ids: List[str], frame_num: int
+    ) -> Dict[str, List[Union[Point3D, LidarPoint]]]:
+        """
+        Download the lidar point cloud data for a given set of tasks and frame number.
+
+        Parameters:
+            task_ids: list of task ids to fetch data from
+            frame_num: download point cloud for this particular frame
+
+        Returns:
+            A dictionary from task_id to list of Point3D objects
+
+        """
+        requests = [
+            f"task/{task_id}/frame/{frame_num}" for task_id in task_ids
+        ]
+        progressbar = self.tqdm_bar(
+            total=len(requests),
+            desc="Downloading pointcloud tasks",
+        )
+        results = make_multiple_requests_concurrently(
+            client=self,
+            requests=requests,
+            route=None,
+            progressbar=progressbar,
+        )
+        resp = {}
+
+        for result in results:
+            req, data = result
+            task_id = req.split("/")[1]  # task/<task id>/frame/1 => task_id
+            points = data.get(POINTS_KEY, None)
+            if points is None or len(points) == 0:
+                raise Exception("Response has invalid payload")
+
+            sample_point = points[0]
+            if I_KEY in sample_point.keys():
+                resp[task_id] = [LidarPoint.from_json(pt) for pt in points]
+
+            resp[task_id] = [Point3D.from_json(pt) for pt in points]
+
+        return resp
 
     @deprecated("Prefer calling Dataset.create_custom_index instead.")
     def create_custom_index(

--- a/nucleus/annotation_uploader.py
+++ b/nucleus/annotation_uploader.py
@@ -6,7 +6,7 @@ from nucleus.annotation import Annotation, SegmentationAnnotation
 from nucleus.async_utils import (
     FileFormField,
     FormDataContextHandler,
-    make_many_form_data_requests_concurrently,
+    make_multiple_requests_concurrently,
 )
 from nucleus.constants import MASK_TYPE, SERIALIZED_REQUEST_KEY
 from nucleus.errors import DuplicateIDError
@@ -150,7 +150,7 @@ class AnnotationUploader:
             desc="Local segmentation mask file batches",
         )
 
-        return make_many_form_data_requests_concurrently(
+        return make_multiple_requests_concurrently(
             client=self._client,
             requests=requests,
             route=self._route,

--- a/nucleus/dataset_item_uploader.py
+++ b/nucleus/dataset_item_uploader.py
@@ -14,7 +14,7 @@ from nucleus.async_utils import (
     FileFormData,
     FileFormField,
     FormDataContextHandler,
-    make_many_form_data_requests_concurrently,
+    make_multiple_requests_concurrently,
 )
 
 from .constants import DATASET_ID_KEY, IMAGE_KEY, ITEMS_KEY, UPDATE_KEY
@@ -125,7 +125,7 @@ class DatasetItemUploader:
             desc=f"Uploading {len(items)} items in {len(requests)} batches",
         )
 
-        return make_many_form_data_requests_concurrently(
+        return make_multiple_requests_concurrently(
             self._client,
             requests,
             f"dataset/{dataset_id}/append",


### PR DESCRIPTION
Making individual requests to `download_pointcloud_task(task_id, frame_num)` was slow.

A new method is proposed to allow concurrent fetches of multiple tasks, with `download_pointcloud_tasks(task_ids, frame_num)` 