### PR TITLE
Create dataset from dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.16.10](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.16.10) - 2023-11-22
+
+Allow creating a dataset by crawling all images in a directory, recursively. Also supports privacy mode datasets.
+
+#### Example structure:
+```
+~/Documents/
+    data/
+        2022/
+            - img01.png
+            - img02.png
+        2023/
+            - img01.png
+            - img02.png
+```
+
+#### Default Example:
+
+```python
+data_dir = "~/Documents/data"
+client.create_dataset_from_dir(data_dir)
+# this will create a dataset named "data" and will contain 4 images, with the ref IDs:
+# ["2022/img01.png", "2022/img02.png", "2023/img01.png", "2023/img02.png"]
+```
+
+#### Example Privacy Mode:
+
+This requires that a proxy (or file server) is setup  and can serve files _relative_ to the data_dir
+
+```python
+data_dir = "~/Documents/data"
+client.create_dataset_from_dir(
+    data_dir,
+    dataset_name='my-dataset',
+    use_privacy_mode=True,
+    privacy_mode_proxy="http://localhost:5000/assets/"
+)
+```
+
+This would create a dataset `my-dataset`, and when opened in Nucleus, the images would be requested to the path:
+`<privacy_mode_proxy>/<img ref id>`, for example: `http://localhost:5000/assets/2022/img01.png`
+
+
 ## [0.16.9](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.16.9) - 2023-11-17
 
 ### Fixes

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1185,6 +1185,7 @@ class NucleusClient:
         dirname: str,
         dataset_name: Optional[str] = None,
         use_privacy_mode: bool = False,
+        privacy_mode_proxy: str = "",
         file_ext_globs: Tuple[str] = ("png", "jpg", "jpeg"),
         skip_size_warning: bool = False,
     ):
@@ -1193,11 +1194,17 @@ class NucleusClient:
         A DatasetItem will be created for each unique image found.
 
         Parameters:
+            dirname: Where to look for image files, recursively
             dataset_name: If none is given, the parent folder name is used
             use_privacy_mode: Whether the dataset should be treated as privacy
+            privacy_mode_proxy: Endpoint that serves image files for privacy mode, ignore if not using privacy mode.
+                The proxy should work based on the relative path of the images in the directory.
             file_ext_globs: Which file type extensions to glob
             skip_size_warning: If False, it will throw an error if the script globs more than 500 images. This is a safety check in case the dirname has a typo, and grabs too much data.
         """
+
+        if use_privacy_mode:
+            assert privacy_mode_proxy, f"When using privacy mode, must specify a proxy to serve the files"
 
         # ensures path does not end with a slash
         _dirname = os.path.join(os.path.expanduser(dirname), "")
@@ -1209,7 +1216,7 @@ class NucleusClient:
         folder_name = os.path.basename(_dirname.rstrip("/"))
         dataset_name = dataset_name or folder_name
         items = create_items_from_folder_crawl(
-            _dirname, file_ext_globs, use_privacy_mode, skip_size_warning
+            _dirname, file_ext_globs, use_privacy_mode, privacy_mode_proxy, skip_size_warning
         )
         if len(items) == 0:
             print(f"Did not find any items in {dirname}")

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1208,7 +1208,7 @@ class NucleusClient:
                 privacy_mode_proxy
             ), "When using privacy mode, must specify a proxy to serve the files"
 
-        # ensures path does not end with a slash
+        # ensures path ends with a slash
         _dirname = os.path.join(os.path.expanduser(dirname), "")
         if not os.path.exists(_dirname):
             raise ValueError(

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1186,7 +1186,7 @@ class NucleusClient:
         dataset_name: Optional[str] = None,
         use_privacy_mode: bool = False,
         privacy_mode_proxy: str = "",
-        file_ext_globs: Tuple[str] = ("png", "jpg", "jpeg"),
+        allowed_file_types: Tuple[str] = ("png", "jpg", "jpeg"),
         skip_size_warning: bool = False,
     ):
         """
@@ -1199,12 +1199,14 @@ class NucleusClient:
             use_privacy_mode: Whether the dataset should be treated as privacy
             privacy_mode_proxy: Endpoint that serves image files for privacy mode, ignore if not using privacy mode.
                 The proxy should work based on the relative path of the images in the directory.
-            file_ext_globs: Which file type extensions to glob
+            allowed_file_types: Which file type extensions to search for, ie: ('jpg', 'png')
             skip_size_warning: If False, it will throw an error if the script globs more than 500 images. This is a safety check in case the dirname has a typo, and grabs too much data.
         """
 
         if use_privacy_mode:
-            assert privacy_mode_proxy, f"When using privacy mode, must specify a proxy to serve the files"
+            assert (
+                privacy_mode_proxy
+            ), f"When using privacy mode, must specify a proxy to serve the files"
 
         # ensures path does not end with a slash
         _dirname = os.path.join(os.path.expanduser(dirname), "")
@@ -1216,7 +1218,11 @@ class NucleusClient:
         folder_name = os.path.basename(_dirname.rstrip("/"))
         dataset_name = dataset_name or folder_name
         items = create_items_from_folder_crawl(
-            _dirname, file_ext_globs, use_privacy_mode, privacy_mode_proxy, skip_size_warning
+            _dirname,
+            allowed_file_types,
+            use_privacy_mode,
+            privacy_mode_proxy,
+            skip_size_warning,
         )
         if len(items) == 0:
             print(f"Did not find any items in {dirname}")
@@ -1227,4 +1233,3 @@ class NucleusClient:
         )
         dataset.append(items, asynchronous=False)
         return dataset
-

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1187,7 +1187,7 @@ class NucleusClient:
         dataset_name: Optional[str] = None,
         use_privacy_mode: bool = False,
         privacy_mode_proxy: str = "",
-        allowed_file_types: Tuple[str] = ("png", "jpg", "jpeg"),
+        allowed_file_types: Tuple[str, ...] = ("png", "jpg", "jpeg"),
         skip_size_warning: bool = False,
     ) -> Union[Dataset, None]:
         """

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -47,7 +47,6 @@ import os
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-
 import pydantic
 import requests
 import tqdm

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -87,6 +87,7 @@ from .constants import (
     ERROR_ITEMS,
     ERROR_PAYLOAD,
     ERRORS_KEY,
+    GLOB_SIZE_THRESHOLD_CHECK,
     I_KEY,
     IMAGE_KEY,
     IMAGE_URL_KEY,
@@ -1188,7 +1189,7 @@ class NucleusClient:
         privacy_mode_proxy: str = "",
         allowed_file_types: Tuple[str] = ("png", "jpg", "jpeg"),
         skip_size_warning: bool = False,
-    ):
+    ) -> Union[Dataset, None]:
         """
         Create a dataset by recursively crawling through a directory.
         A DatasetItem will be created for each unique image found.
@@ -1222,11 +1223,16 @@ class NucleusClient:
             allowed_file_types,
             use_privacy_mode,
             privacy_mode_proxy,
-            skip_size_warning,
         )
+
         if len(items) == 0:
             print(f"Did not find any items in {dirname}")
-            return
+            return None
+
+        if len(items) > GLOB_SIZE_THRESHOLD_CHECK and not skip_size_warning:
+            raise Exception(
+                f"Found over {GLOB_SIZE_THRESHOLD_CHECK} items in {dirname}. If this is intended, set skip_size_warning=True when calling this function."
+            )
 
         dataset = self.create_dataset(
             name=dataset_name, use_privacy_mode=use_privacy_mode

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1206,7 +1206,7 @@ class NucleusClient:
         if use_privacy_mode:
             assert (
                 privacy_mode_proxy
-            ), f"When using privacy mode, must specify a proxy to serve the files"
+            ), "When using privacy mode, must specify a proxy to serve the files"
 
         # ensures path does not end with a slash
         _dirname = os.path.join(os.path.expanduser(dirname), "")

--- a/nucleus/constants.py
+++ b/nucleus/constants.py
@@ -166,3 +166,4 @@ W_KEY = "w"
 X_KEY = "x"
 Y_KEY = "y"
 Z_KEY = "z"
+GLOB_SIZE_THRESHOLD_CHECK = 500

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -433,7 +433,7 @@ def get_image_dimension(image_fpath: str) -> Tuple[int, int]:
 
 
 def find_matching_filepaths(
-    dirname: str, allowed_file_types: Tuple[str]
+    dirname: str, allowed_file_types: Tuple[str, ...]
 ) -> List[str]:
     """
     Returns a list of filepaths *relative* to dirname that matched the file globs
@@ -453,7 +453,7 @@ def find_matching_filepaths(
 
 def create_items_from_folder_crawl(
     dirname: str,
-    allowed_file_types: Tuple[str],
+    allowed_file_types: Tuple[str, ...],
     use_privacy_mode: bool,
     privacy_mode_proxy: str,
 ) -> List[DatasetItem]:

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -435,16 +435,15 @@ def get_image_dimension(image_fpath: str) -> Tuple[int, int]:
 GLOB_SIZE_THRESHOLD_CHECK = 500
 
 
-def create_items_from_folder_crawl(
-    dirname: str,
-    file_globs: Tuple[str],
-    use_privacy_mode: bool,
-    privacy_mode_proxy: str,
-    skip_size_warning: bool,
-) -> List[DatasetItem]:
+def find_matching_filepaths(
+    dirname: str, allowed_file_types: Tuple[str], skip_size_warning: bool
+) -> List[str]:
+    """
+    Returns a list of filepaths *relative* to dirname that matched the file globs
+    """
     relative_fpaths = []
-    for file_glob in file_globs:
-        pathname = f"**/*.{file_glob}"
+    for file_type in allowed_file_types:
+        pathname = f"**/*.{file_type}"
         print(f"Searching for {pathname} in root dir: {dirname}")
         fpaths = glob.glob(pathname=pathname, root_dir=dirname, recursive=True)
         relative_fpaths.extend(fpaths)
@@ -456,6 +455,19 @@ def create_items_from_folder_crawl(
             raise Exception(
                 f"Found over {GLOB_SIZE_THRESHOLD_CHECK} items in {dirname}. If this is intended, set skip_size_warning=True when calling this function."
             )
+    return relative_fpaths
+
+
+def create_items_from_folder_crawl(
+    dirname: str,
+    allowed_file_types: Tuple[str],
+    use_privacy_mode: bool,
+    privacy_mode_proxy: str,
+    skip_size_warning: bool,
+) -> List[DatasetItem]:
+    relative_fpaths = find_matching_filepaths(
+        dirname, allowed_file_types, skip_size_warning
+    )
 
     dataset_items = []
     for relative_fpath in relative_fpaths:

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -8,9 +8,8 @@ from collections import defaultdict
 from typing import IO, TYPE_CHECKING, Dict, List, Sequence, Tuple, Type, Union
 
 import requests
-from requests.models import HTTPError
 from PIL import Image
-
+from requests.models import HTTPError
 
 from nucleus.annotation import (
     Annotation,

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -439,6 +439,7 @@ def create_items_from_folder_crawl(
     dirname: str,
     file_globs: Tuple[str],
     use_privacy_mode: bool,
+    privacy_mode_proxy: str,
     skip_size_warning: bool,
 ) -> List[DatasetItem]:
     relative_fpaths = []
@@ -459,10 +460,13 @@ def create_items_from_folder_crawl(
     dataset_items = []
     for relative_fpath in relative_fpaths:
         ref_id = relative_fpath
+
         image_fpath = os.path.join(dirname, relative_fpath)
         width, height = None, None
+
         if use_privacy_mode:
             width, height = get_image_dimension(image_fpath)
+            image_fpath = os.path.join(privacy_mode_proxy, relative_fpath)
 
         item = DatasetItem(
             image_location=image_fpath,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.16.9"
+version = "0.16.10"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Allow creating a dataset by crawling all images in a directory, recursively.

Also supports privacy mode datasets.

#### Example structure:
```
~/Documents/
    data/
        2022/
            - img01.png
            - img02.png
        2023/
            - img01.png
            - img02.png
```

#### Example Default:

```python
data_dir = "~/Documents/data"
client.create_dataset_from_dir(data_dir)
# this will create a dataset named "data" and will contain 4 images, with the ref IDs:
# ["2022/img01.png", "2022/img02.png", "2023/img01.png", "2023/img02.png"]
```



#### Example Privacy Mode:

This requires that a proxy (or file server) is setup  and can serve files _relative_ to the data_dir

```python
data_dir = "~/Documents/data"
client.create_dataset_from_dir(
    data_dir,
    dataset_name='my-dataset',
    use_privacy_mode=True,
    privacy_mode_proxy="http://localhost:5000/assets/"
)
```

This would create a dataset `my-dataset`, and when opened in Nucleus, the images would be requested to the path:
`<privacy_mode_proxy>/<img ref id>`, for example: `http://localhost:5000/assets/2022/img01.png`