### PR TITLE
Updated model to include trained_slice_id

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -116,6 +116,7 @@ from .constants import (
     SLICE_ID_KEY,
     SLICE_TAGS_KEY,
     STATUS_CODE_KEY,
+    TRAINED_SLICE_ID_KEY,
     UPDATE_KEY,
 )
 from .data_transfer_object.dataset_details import DatasetDetails
@@ -239,6 +240,7 @@ class NucleusClient:
                 metadata=model["metadata"] or None,
                 client=self,
                 tags=model.get(MODEL_TAGS_KEY, []),
+                trained_slice_id=model.get(TRAINED_SLICE_ID_KEY, None),
             )
             for model in model_objects["models"]
         ]
@@ -552,6 +554,7 @@ class NucleusClient:
         metadata: Optional[Dict] = None,
         bundle_name: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        trained_slice_id: Optional[str] = None,
     ) -> Model:
         """Adds a :class:`Model` to Nucleus.
 
@@ -571,7 +574,12 @@ class NucleusClient:
         """
         response = self.make_request(
             construct_model_creation_payload(
-                name, reference_id, metadata, bundle_name, tags
+                name,
+                reference_id,
+                metadata,
+                bundle_name,
+                tags,
+                trained_slice_id,
             ),
             "models/add",
         )
@@ -587,6 +595,7 @@ class NucleusClient:
             bundle_name=bundle_name,
             client=self,
             tags=tags,
+            trained_slice_id=trained_slice_id,
         )
 
     def create_launch_model(
@@ -595,6 +604,7 @@ class NucleusClient:
         reference_id: str,
         bundle_args: Dict[str, Any],
         metadata: Optional[Dict] = None,
+        trained_slice_id: Optional[str] = None,
     ) -> Model:
         """
         Adds a :class:`Model` to Nucleus, as well as a Launch bundle from a given function.
@@ -686,6 +696,7 @@ class NucleusClient:
             reference_id,
             metadata,
             bundle_name,
+            trained_slice_id=trained_slice_id,
         )
 
     def create_launch_model_from_dir(
@@ -694,6 +705,7 @@ class NucleusClient:
         reference_id: str,
         bundle_from_dir_args: Dict[str, Any],
         metadata: Optional[Dict] = None,
+        trained_slice_id: Optional[str] = None,
     ) -> Model:
         """
         Adds a :class:`Model` to Nucleus, as well as a Launch bundle from a directory.
@@ -808,6 +820,7 @@ class NucleusClient:
             reference_id,
             metadata,
             bundle_name,
+            trained_slice_id=trained_slice_id,
         )
 
     @deprecated(

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -438,6 +438,7 @@ class Dataset:
         model_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         annotation_metadata_schema: Optional[Dict] = None,
+        trained_slice_id: Optional[str] = None,
     ):
         payload = construct_model_run_creation_payload(
             name,
@@ -445,6 +446,7 @@ class Dataset:
             model_id,
             metadata,
             annotation_metadata_schema,
+            trained_slice_id,
         )
         return self._client.create_model_run(self.id, payload)
 

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -119,7 +119,7 @@ class Model:
         self.trained_slice_id = trained_slice_id
 
     def __repr__(self):
-        return f"Model(model_id='{self.id}', name='{self.name}', reference_id='{self.reference_id}', metadata={self.metadata}, bundle_name={self.bundle_name}, tags={self.tags}, client={self._client}, trained_slice_id={self.trained_slice_id})"
+        return f"Model(model_id='{self.id}', name='{self.name}', reference_id='{self.reference_id}', metadata={self.metadata}, bundle_name={self.bundle_name}, tags={self.tags}, client={self._client}"
 
     def __eq__(self, other):
         return (

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -3,7 +3,13 @@ from typing import Dict, List, Optional, Union
 import requests
 
 from .async_job import AsyncJob
-from .constants import METADATA_KEY, MODEL_TAGS_KEY, NAME_KEY, REFERENCE_ID_KEY
+from .constants import (
+    METADATA_KEY,
+    MODEL_TAGS_KEY,
+    NAME_KEY,
+    REFERENCE_ID_KEY,
+    TRAINED_SLICE_ID_KEY,
+)
 from .dataset import Dataset
 from .model_run import ModelRun
 from .prediction import (
@@ -101,6 +107,7 @@ class Model:
         client,
         bundle_name=None,
         tags=None,
+        trained_slice_id=None,
     ):
         self.id = model_id
         self.name = name
@@ -109,9 +116,10 @@ class Model:
         self.bundle_name = bundle_name
         self.tags = tags if tags else []
         self._client = client
+        self.trained_slice_id = trained_slice_id
 
     def __repr__(self):
-        return f"Model(model_id='{self.id}', name='{self.name}', reference_id='{self.reference_id}', metadata={self.metadata}, bundle_name={self.bundle_name}, tags={self.tags}, client={self._client})"
+        return f"Model(model_id='{self.id}', name='{self.name}', reference_id='{self.reference_id}', metadata={self.metadata}, bundle_name={self.bundle_name}, tags={self.tags}, client={self._client}, trained_slice_id={self.trained_slice_id})"
 
     def __eq__(self, other):
         return (
@@ -120,6 +128,7 @@ class Model:
             and (self.metadata == other.metadata)
             and (self._client == other._client)
             and (self.bundle_name == other.bundle_name)
+            and (self.trained_slice_id == other.trained_slice_id)
         )
 
     def __hash__(self):
@@ -134,6 +143,7 @@ class Model:
             reference_id=payload["ref_id"],
             metadata=payload["metadata"] or None,
             client=client,
+            trained_slice_id=payload.get(TRAINED_SLICE_ID_KEY, None),
         )
 
     def create_run(

--- a/nucleus/payload_constructor.py
+++ b/nucleus/payload_constructor.py
@@ -137,6 +137,7 @@ def construct_model_creation_payload(
     metadata: Optional[Dict],
     bundle_name: Optional[str],
     tags: Optional[List[str]],
+    trained_slice_id: Optional[str],
 ) -> dict:
     payload = {
         NAME_KEY: name,
@@ -144,6 +145,8 @@ def construct_model_creation_payload(
         METADATA_KEY: metadata if metadata else {},
     }
 
+    if trained_slice_id:
+        payload[TRAINED_SLICE_ID_KEY] = trained_slice_id
     if bundle_name:
         payload[MODEL_BUNDLE_NAME_KEY] = bundle_name
     if tags:
@@ -158,6 +161,7 @@ def construct_model_run_creation_payload(
     model_id: Optional[str],
     metadata: Optional[Dict],
     annotation_metadata_schema: Optional[Dict] = None,
+    trained_slice_id: Optional[str] = None,
 ) -> dict:
     payload = {
         NAME_KEY: name,
@@ -167,11 +171,14 @@ def construct_model_run_creation_payload(
         payload[REFERENCE_ID_KEY] = reference_id
     if model_id:
         payload[MODEL_ID_KEY] = model_id
+    if trained_slice_id:
+        payload[TRAINED_SLICE_ID_KEY] = trained_slice_id
     return {
         NAME_KEY: name,
         REFERENCE_ID_KEY: reference_id,
         METADATA_KEY: metadata if metadata else {},
         ANNOTATION_METADATA_SCHEMA_KEY: annotation_metadata_schema,
+        TRAINED_SLICE_ID_KEY: trained_slice_id,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.16.12"
+version = "0.16.13"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Added trained_slice_id field to the model object.

This was previously added to [upload_predictions](https://github.com/scaleapi/nucleus-python-client/blob/master/nucleus/dataset.py#L1797) in [Vayun's PR](https://github.com/scaleapi/nucleus-python-client/pull/417). I am still learning my way around the repo, so please let me know if this addition is correct or necessary.