### PR TITLE
Concurrent lidar pcl fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.15](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.16.15) - 2024-01-11
+
+### Fixes
+- Fix lidar concurrent lidar pointcloud to also return intensity in case it exists in the response. 
+
 ## [0.16.14](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.16.14) - 2024-01-03
 
 ### Fixes

--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -1119,8 +1119,8 @@ class NucleusClient:
             sample_point = points[0]
             if I_KEY in sample_point.keys():
                 resp[task_id] = [LidarPoint.from_json(pt) for pt in points]
-
-            resp[task_id] = [Point3D.from_json(pt) for pt in points]
+            else:
+                resp[task_id] = [Point3D.from_json(pt) for pt in points]
 
         return resp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.16.14"
+version = "0.16.15"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
Before it would always overwrite the `LidarPoint` to `Point3D` which drops the intensity which is not desired. Test with any 3D task of an annotation project.