### PR TITLE
fix: reverts test_dataset_update_metadata_local

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -155,7 +155,7 @@ def test_dataset_update_metadata_local(dataset):
     )
     resulting_item = dataset.iloc(0)["item"]
     print(resulting_item)
-    assert resulting_item.metadata["snake_field"] == 0
+    assert resulting_item.metadata["snake_field"] == 1
 
 
 def test_dataset_update_metadata(dataset):


### PR DESCRIPTION
snake_field must be 1 since second dataset append overrides the existing one (update=True)