### PR TITLE
Allow image+annotation generator to give mirrored URLs

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1447,6 +1447,7 @@ class Dataset:
     def items_and_annotation_generator(
         self,
         query: Optional[str] = None,
+        use_mirrored_images: bool = False,
     ) -> Iterable[Dict[str, Union[DatasetItem, Dict[str, List[Annotation]]]]]:
         """Provides a generator of all DatasetItems and Annotations in the dataset.
 
@@ -1477,6 +1478,7 @@ class Dataset:
             result_key=EXPORT_FOR_TRAINING_KEY,
             page_size=10000,  # max ES page size
             query=query,
+            chip=use_mirrored_images,
         )
         for data in json_generator:
             for ia in convert_export_payload([data], has_predictions=False):

--- a/nucleus/dataset_item.py
+++ b/nucleus/dataset_item.py
@@ -18,6 +18,7 @@ from .constants import (
     METADATA_KEY,
     ORIGINAL_IMAGE_URL_KEY,
     POINTCLOUD_URL_KEY,
+    PROCESSED_URL_KEY,
     REFERENCE_ID_KEY,
     TYPE_KEY,
     URL_KEY,
@@ -156,8 +157,10 @@ class DatasetItem:  # pylint: disable=R0902
     @classmethod
     def from_json(cls, payload: dict):
         """Instantiates dataset item object from schematized JSON dict payload."""
-        image_url = payload.get(IMAGE_URL_KEY, None) or payload.get(
-            ORIGINAL_IMAGE_URL_KEY, None
+        image_url = (
+            payload.get(PROCESSED_URL_KEY, None)
+            or payload.get(IMAGE_URL_KEY, None)
+            or payload.get(ORIGINAL_IMAGE_URL_KEY, None)
         )
         pointcloud_url = payload.get(POINTCLOUD_URL_KEY, None)
 


### PR DESCRIPTION
We use the items_and_annotation_generator to fetch images and annotations for ML training. Sometimes the original image URL is no longer accessible to us and we need to fetch the Scale-mirrored URL instead.

I am open to changing the `use_mirrored_images` flag to whatever name is most memorable.