### PR TITLE
wrapper for uploading LSS predictions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             mkdir test_results
             set -e
             TEST_FILES=$(circleci tests glob "tests/**/test_*.py")
-            echo "$TEST_FILES" | circleci tests run --command "xargs poetry run coverage run --include=nucleus/* -m pytest -n 2 -s -v -o junit_family=legacy --junitxml=test_results/junit.xml" --verbose --split-by=timings
+            echo "$TEST_FILES" | circleci tests run --command "xargs poetry run coverage run --include=nucleus/* -m pytest -s -v -o junit_family=legacy --junitxml=test_results/junit.xml" --verbose --split-by=timings
             poetry run coverage report
             poetry run coverage html
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             mkdir test_results
             set -e
             TEST_FILES=$(circleci tests glob "tests/**/test_*.py")
-            echo "$TEST_FILES" | circleci tests run --command "xargs poetry run coverage run --include=nucleus/* -m pytest -n auto -s -v -o junit_family=legacy --junitxml=test_results/junit.xml" --verbose --split-by=timings
+            echo "$TEST_FILES" | circleci tests run --command "xargs poetry run coverage run --include=nucleus/* -m pytest -n 2 -s -v -o junit_family=legacy --junitxml=test_results/junit.xml" --verbose --split-by=timings
             poetry run coverage report
             poetry run coverage html
       - store_test_results:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.5](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.17.5) - 2024-04-15
+
+### Added
+- Method for uploading lidar semantic segmentation predictions, via `dataset.upload_lidar_semseg_predictions`
+
+Example usage:
+
+```python
+dataset = client.get_dataset("ds_...")
+model = client.get_model("prj_...")
+pointcloud_ref_id = 'pc_ref_1'
+predictions_s3 = "s3://temp/predictions.json"
+
+dataset.upload_lidar_semseg_predictions(model, pointcloud_ref_id, predictions_s3)
+```
+
+For the expected format of the s3 predictions, refer to the [documentation here](https://docs.nucleus.scale.com/en/latest/api/nucleus/index.html#nucleus.Dataset.upload_lidar_semseg_predictions)
+
+
 ## [0.17.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.17.4) - 2024-03-25
 
 ### Modified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.17.4"
+version = "0.17.5"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
- Method for uploading lidar semantic segmentation predictions, via `dataset.upload_lidar_semseg_predictions`

Example usage:

```python
dataset = client.get_dataset("ds_...")
model = client.get_model("prj_...")
pointcloud_ref_id = 'pc_ref_1'
predictions_s3 = "s3://temp/predictions.json"

dataset.upload_lidar_semseg_predictions(model, pointcloud_ref_id, predictions_s3)
```

For the expected format of the s3 predictions, refer to the [documentation here](https://docs.nucleus.scale.com/en/latest/api/nucleus/index.html#nucleus.Dataset.upload_lidar_semseg_predictions)
