### PR TITLE
[DE-4655] Add slice parameter to scene and annotation generator python client

### DIFF
--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1449,10 +1449,13 @@ class Dataset:
         )
         return convert_export_payload(api_payload[EXPORTED_ROWS])
 
-    def scene_and_annotation_generator(self, page_size: int = 10):
+    def scene_and_annotation_generator(
+        self, sliceId=None, page_size: int = 10
+    ):
         """Provides a generator of all Scenes and Annotations in the dataset grouped by scene.
 
         Args:
+            sliceId: Optional slice ID to filter the scenes and annotations.
             page_size: Number of scenes to fetch per page. Default is 10.
 
         Returns:
@@ -1505,6 +1508,7 @@ class Dataset:
             endpoint=f"dataset/{self.id}/{endpoint_name}",
             result_key=EXPORT_FOR_TRAINING_KEY,
             page_size=page_size,
+            sliceId=sliceId,
         )
 
         for data in json_generator:


### PR DESCRIPTION
Adding a slice param to the scene and annotation generator so we can only extract a subset of scenes and their annotations. Helpful for large datasets where some scenes are not consistent with others. 

Related to https://github.com/scaleapi/scaleapi/pull/99629, merge this one after that one.
