### PR TITLE
Add dataset tags to SDK for identification (DE-7033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.18.2) - 2026-05-08
+
+### Added
+- Dataset tags are now exposed through the SDK so customers can identify datasets labeled by Scale vs other vendors. `Dataset.info()` now returns a `tags` field, and `Dataset` exposes `get_tags()`, `add_tags()`, and `remove_tags()` methods.
+
 ## [0.18.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.18.1) - 2026-05-05
 
 ### Changed

--- a/nucleus/data_transfer_object/dataset_info.py
+++ b/nucleus/data_transfer_object/dataset_info.py
@@ -1,4 +1,12 @@
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from pydantic.v1 import validator
+else:
+    try:
+        from pydantic.v1 import validator
+    except ImportError:
+        from pydantic import validator
 
 from nucleus.pydantic_base import DictCompatibleModel
 
@@ -14,6 +22,7 @@ class DatasetInfo(DictCompatibleModel):
         slice_ids: List :class:`Slice` IDs associated with the :class:`Dataset`
         annotation_metadata_schema: Dict defining annotation-level metadata schema.
         item_metadata_schema: Dict defining item metadata schema.
+        tags: List of tags associated with the :class:`Dataset`.
     """
 
     dataset_id: str
@@ -24,3 +33,8 @@ class DatasetInfo(DictCompatibleModel):
     # TODO: Expand the following into pydantic models to formalize schema
     annotation_metadata_schema: Optional[Dict[str, Any]] = None
     item_metadata_schema: Optional[Dict[str, Any]] = None
+    tags: List[str] = []
+
+    @validator("tags", pre=True, always=True)  # pylint: disable=used-before-assignment
+    def coerce_null_tags(cls, v):  # pylint: disable=no-self-argument
+        return v if v is not None else []

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -433,6 +433,49 @@ class Dataset:
         dataset_info = DatasetInfo.parse_obj(response)
         return dataset_info
 
+    def get_tags(self) -> List[str]:
+        """Fetches tags associated with the dataset.
+
+        Returns:
+            List of tag strings associated with this dataset.
+        """
+        response = self._client.make_request(
+            {}, f"dataset/{self.id}/tags", requests.get
+        )
+        return response["tags"]
+
+    def add_tags(self, tags: List[str]) -> List[str]:
+        """Adds tags to the dataset.
+
+        Args:
+            tags: List of tag strings to add.
+
+        Returns:
+            Updated list of all tags on the dataset.
+        """
+        if isinstance(tags, str):
+            raise TypeError("tags must be a list of strings, not a single string")
+        response = self._client.make_request(
+            {"tags": tags}, f"dataset/{self.id}/tags", requests.post
+        )
+        return response["tags"]
+
+    def remove_tags(self, tags: List[str]) -> List[str]:
+        """Removes tags from the dataset.
+
+        Args:
+            tags: List of tag strings to remove.
+
+        Returns:
+            Updated list of remaining tags on the dataset.
+        """
+        if isinstance(tags, str):
+            raise TypeError("tags must be a list of strings, not a single string")
+        response = self._client.make_request(
+            {"tags": tags}, f"dataset/{self.id}/tags", requests.delete
+        )
+        return response["tags"]
+
     @deprecated(
         "Model runs have been deprecated and will be removed. Use a Model instead"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.18.1"
+version = "0.18.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -257,6 +257,41 @@ def test_dataset_slices(CLIENT, dataset):
     # TODO(gunnar): Test slice items -> Split up info!
 
 
+def test_dataset_tags(CLIENT, dataset):
+    # Fresh dataset should have no tags
+    assert dataset.get_tags() == []
+
+    # Add tags
+    updated = dataset.add_tags(["Labeled by: Scale", "production"])
+    assert "Labeled by: Scale" in updated
+    assert "production" in updated
+
+    # Info should include tags
+    info = dataset.info()
+    assert "Labeled by: Scale" in info.tags
+    assert "production" in info.tags
+
+    # Adding duplicate tags is idempotent
+    updated2 = dataset.add_tags(["production", "v2"])
+    assert "production" in updated2
+    assert "v2" in updated2
+
+    # Remove tags
+    remaining = dataset.remove_tags(["production"])
+    assert "production" not in remaining
+    assert "Labeled by: Scale" in remaining
+
+    # Removing non-existent tags is idempotent
+    remaining2 = dataset.remove_tags(["nonexistent"])
+    assert remaining2 == remaining
+
+    # String argument should raise TypeError
+    with pytest.raises(TypeError):
+        dataset.add_tags("not a list")
+    with pytest.raises(TypeError):
+        dataset.remove_tags("not a list")
+
+
 def test_dataset_append_local(CLIENT, dataset):
     ds_items_local_error = [
         DatasetItem(


### PR DESCRIPTION
## Summary
- Add `tags` field to `DatasetInfo` model so `dataset.info()` returns dataset tags
- Add `get_tags()`, `add_tags()`, `remove_tags()` methods to `Dataset` class for programmatic tag management
- Enables customers (e.g. Redwoods) to identify via API whether a dataset was labeled by Scale or another vendor

## Test plan
- [ ] Verify `dataset.info()` returns tags for a dataset with tags set in the UI
- [ ] Verify `dataset.add_tags(["Labeled by: Scale"])` adds tags
- [ ] Verify `dataset.get_tags()` returns the current tag list
- [ ] Verify `dataset.remove_tags(["Labeled by: Scale"])` removes tags
- [ ] Verify backward compatibility — `dataset.info()` works against a server that doesn't yet return tags (defaults to `[]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds `tags` field to `DatasetInfo` (with a null-coercing validator for backward compatibility) and three new `Dataset` methods — `get_tags()`, `add_tags()`, and `remove_tags()` — that delegate to a new `/dataset/{id}/tags` endpoint.
- `remove_tags` uses HTTP DELETE with a JSON body, which works with the current `make_request` plumbing but may be silently stripped by some intermediary infrastructure.
- The `coerce_null_tags` Pydantic validator is missing the `@classmethod` decorator, relying on a `pylint: disable` comment instead of following the recommended v1 style.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no P0 or P1 issues; only P2 style suggestions.

The change is well-scoped, backward-compatible (null-coercing validator + field default), and consistent with existing codebase patterns. Both findings are P2: a missing @classmethod decorator on the validator and a note about DELETE-with-body infrastructure risk. Neither blocks correctness.

No files require special attention; nucleus/dataset.py and dataset_info.py are the only changed files worth reviewing closely.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| nucleus/data_transfer_object/dataset_info.py | Adds `tags: List[str] = []` field with a null-coercing validator for backward compatibility; validator is missing `@classmethod` decorator. |
| nucleus/dataset.py | Adds `get_tags()`, `add_tags()`, and `remove_tags()` methods; consistent with existing `make_request` patterns; `remove_tags` uses HTTP DELETE with a JSON body. |
| tests/test_dataset.py | Adds `test_dataset_tags` covering happy path, idempotency, and type-safety guard; comprehensive coverage of the new API surface. |
| CHANGELOG.md | Adds 0.18.2 changelog entry describing the new dataset tags feature. |
| pyproject.toml | Bumps version from 0.18.1 to 0.18.2. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Dataset
    participant NucleusClient
    participant API

    User->>Dataset: dataset.info()
    Dataset->>NucleusClient: "make_request({}, dataset/{id}/info, GET)"
    NucleusClient->>API: "GET /dataset/{id}/info"
    API-->>NucleusClient: "{tags: [...], ...}"
    NucleusClient-->>Dataset: response dict
    Dataset-->>User: "DatasetInfo(tags=[...])"

    User->>Dataset: dataset.get_tags()
    Dataset->>NucleusClient: "make_request({}, dataset/{id}/tags, GET)"
    NucleusClient->>API: "GET /dataset/{id}/tags"
    API-->>NucleusClient: "{tags: [...]}"
    NucleusClient-->>Dataset: response[tags]
    Dataset-->>User: List[str]

    User->>Dataset: dataset.add_tags([Labeled by Scale])
    Dataset->>NucleusClient: "make_request({tags:[...]}, dataset/{id}/tags, POST)"
    NucleusClient->>API: "POST /dataset/{id}/tags"
    API-->>NucleusClient: "{tags: [...]}"
    NucleusClient-->>Dataset: response[tags]
    Dataset-->>User: List[str]

    User->>Dataset: dataset.remove_tags([Labeled by Scale])
    Dataset->>NucleusClient: "make_request({tags:[...]}, dataset/{id}/tags, DELETE)"
    NucleusClient->>API: "DELETE /dataset/{id}/tags body:{tags:[...]}"
    API-->>NucleusClient: "{tags: [...]}"
    NucleusClient-->>Dataset: response[tags]
    Dataset-->>User: List[str]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anucleus%2Fdata_transfer_object%2Fdataset_info.py%3A38-39%0APydantic%20v1's%20%60%40validator%60%20is%20a%20classmethod%20under%20the%20hood%2C%20but%20the%20recommended%20practice%20%28and%20what%20mypy%20expects%29%20is%20to%20also%20apply%20%60%40classmethod%60%20explicitly.%20Without%20it%2C%20type%20checkers%20may%20infer%20%60cls%60%20as%20the%20first%20argument%20type%20incorrectly%2C%20and%20the%20%60%23%20pylint%3A%20disable%3Dno-self-argument%60%20suppression%20is%20papering%20over%20the%20real%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40validator%28%22tags%22%2C%20pre%3DTrue%2C%20always%3DTrue%29%20%20%23%20pylint%3A%20disable%3Dused-before-assignment%0A%20%20%20%20%40classmethod%0A%20%20%20%20def%20coerce_null_tags%28cls%2C%20v%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anucleus%2Fdataset.py%3A474-477%0A%60remove_tags%60%20passes%20a%20request%20body%20via%20%60requests.delete%60.%20The%20%60requests%60%20library%20supports%20this%2C%20and%20%60make_request%60%20correctly%20forwards%20it%20as%20%60json%3Dpayload%60.%20However%2C%20some%20HTTP%20intermediaries%20%28proxies%2C%20load%20balancers%2C%20AWS%20API%20Gateway%29%20silently%20strip%20bodies%20from%20DELETE%20requests%2C%20which%20would%20cause%20the%20server%20to%20receive%20an%20empty%20%60tags%60%20list%20and%20could%20delete%20all%20tags%20instead%20of%20just%20the%20specified%20ones.%20If%20the%20backend%20supports%20a%20query-parameter%20approach%20or%20a%20dedicated%20%60DELETE%20%2Fdataset%2F%7Bid%7D%2Ftags%2F%7Btag%7D%60%20sub-resource%20route%2C%20that%20would%20be%20more%20reliable%20across%20infrastructure.%0A%0A&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anucleus%2Fdata_transfer_object%2Fdataset_info.py%3A38-39%0APydantic%20v1's%20%60%40validator%60%20is%20a%20classmethod%20under%20the%20hood%2C%20but%20the%20recommended%20practice%20%28and%20what%20mypy%20expects%29%20is%20to%20also%20apply%20%60%40classmethod%60%20explicitly.%20Without%20it%2C%20type%20checkers%20may%20infer%20%60cls%60%20as%20the%20first%20argument%20type%20incorrectly%2C%20and%20the%20%60%23%20pylint%3A%20disable%3Dno-self-argument%60%20suppression%20is%20papering%20over%20the%20real%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40validator%28%22tags%22%2C%20pre%3DTrue%2C%20always%3DTrue%29%20%20%23%20pylint%3A%20disable%3Dused-before-assignment%0A%20%20%20%20%40classmethod%0A%20%20%20%20def%20coerce_null_tags%28cls%2C%20v%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anucleus%2Fdataset.py%3A474-477%0A%60remove_tags%60%20passes%20a%20request%20body%20via%20%60requests.delete%60.%20The%20%60requests%60%20library%20supports%20this%2C%20and%20%60make_request%60%20correctly%20forwards%20it%20as%20%60json%3Dpayload%60.%20However%2C%20some%20HTTP%20intermediaries%20%28proxies%2C%20load%20balancers%2C%20AWS%20API%20Gateway%29%20silently%20strip%20bodies%20from%20DELETE%20requests%2C%20which%20would%20cause%20the%20server%20to%20receive%20an%20empty%20%60tags%60%20list%20and%20could%20delete%20all%20tags%20instead%20of%20just%20the%20specified%20ones.%20If%20the%20backend%20supports%20a%20query-parameter%20approach%20or%20a%20dedicated%20%60DELETE%20%2Fdataset%2F%7Bid%7D%2Ftags%2F%7Btag%7D%60%20sub-resource%20route%2C%20that%20would%20be%20more%20reliable%20across%20infrastructure.%0A%0A&repo=scaleapi%2Fnucleus-python-client&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fnucleus-python-client%22%20on%20the%20existing%20branch%20%22vinayparakala%2Fde-7033-add-dataset-tags-to-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22vinayparakala%2Fde-7033-add-dataset-tags-to-sdk%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anucleus%2Fdata_transfer_object%2Fdataset_info.py%3A38-39%0APydantic%20v1's%20%60%40validator%60%20is%20a%20classmethod%20under%20the%20hood%2C%20but%20the%20recommended%20practice%20%28and%20what%20mypy%20expects%29%20is%20to%20also%20apply%20%60%40classmethod%60%20explicitly.%20Without%20it%2C%20type%20checkers%20may%20infer%20%60cls%60%20as%20the%20first%20argument%20type%20incorrectly%2C%20and%20the%20%60%23%20pylint%3A%20disable%3Dno-self-argument%60%20suppression%20is%20papering%20over%20the%20real%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40validator%28%22tags%22%2C%20pre%3DTrue%2C%20always%3DTrue%29%20%20%23%20pylint%3A%20disable%3Dused-before-assignment%0A%20%20%20%20%40classmethod%0A%20%20%20%20def%20coerce_null_tags%28cls%2C%20v%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anucleus%2Fdataset.py%3A474-477%0A%60remove_tags%60%20passes%20a%20request%20body%20via%20%60requests.delete%60.%20The%20%60requests%60%20library%20supports%20this%2C%20and%20%60make_request%60%20correctly%20forwards%20it%20as%20%60json%3Dpayload%60.%20However%2C%20some%20HTTP%20intermediaries%20%28proxies%2C%20load%20balancers%2C%20AWS%20API%20Gateway%29%20silently%20strip%20bodies%20from%20DELETE%20requests%2C%20which%20would%20cause%20the%20server%20to%20receive%20an%20empty%20%60tags%60%20list%20and%20could%20delete%20all%20tags%20instead%20of%20just%20the%20specified%20ones.%20If%20the%20backend%20supports%20a%20query-parameter%20approach%20or%20a%20dedicated%20%60DELETE%20%2Fdataset%2F%7Bid%7D%2Ftags%2F%7Btag%7D%60%20sub-resource%20route%2C%20that%20would%20be%20more%20reliable%20across%20infrastructure.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
nucleus/data_transfer_object/dataset_info.py:38-39
Pydantic v1's `@validator` is a classmethod under the hood, but the recommended practice (and what mypy expects) is to also apply `@classmethod` explicitly. Without it, type checkers may infer `cls` as the first argument type incorrectly, and the `# pylint: disable=no-self-argument` suppression is papering over the real fix.

```suggestion
    @validator("tags", pre=True, always=True)  # pylint: disable=used-before-assignment
    @classmethod
    def coerce_null_tags(cls, v):
```

### Issue 2 of 2
nucleus/dataset.py:474-477
`remove_tags` passes a request body via `requests.delete`. The `requests` library supports this, and `make_request` correctly forwards it as `json=payload`. However, some HTTP intermediaries (proxies, load balancers, AWS API Gateway) silently strip bodies from DELETE requests, which would cause the server to receive an empty `tags` list and could delete all tags instead of just the specified ones. If the backend supports a query-parameter approach or a dedicated `DELETE /dataset/{id}/tags/{tag}` sub-resource route, that would be more reliable across infrastructure.

`````

</details>

<sub>Reviews (9): Last reviewed commit: ["Add dataset tags to SDK for identificati..."](https://github.com/scaleapi/nucleus-python-client/commit/ce37cc430c1c25b847f67538b8481d27a7794d18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27505885)</sub>

<!-- /greptile_comment -->