### PR TITLE
Add local pHash deduplication utility

### DIFF
--- a/nucleus/__init__.py
+++ b/nucleus/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "DeduplicationJob",
     "DeduplicationResult",
     "DeduplicationStats",
+    "LocalDeduplicationResult",
     "BoxPrediction",
     "CameraParams",
     "CategoryAnnotation",
@@ -43,6 +44,7 @@ __all__ = [
     "SegmentationPrediction",
     "Slice",
     "VideoScene",
+    "deduplicate_by_phash",
 ]
 
 import datetime
@@ -147,6 +149,10 @@ from .errors import (
     NucleusAPIError,
 )
 from .job import CustomerJobTypes
+from .local_deduplication import (
+    LocalDeduplicationResult,
+    deduplicate_by_phash,
+)
 from .model import Model
 from .model_run import ModelRun
 from .payload_constructor import (

--- a/nucleus/data_transfer_object/dataset_info.py
+++ b/nucleus/data_transfer_object/dataset_info.py
@@ -35,6 +35,8 @@ class DatasetInfo(DictCompatibleModel):
     item_metadata_schema: Optional[Dict[str, Any]] = None
     tags: List[str] = []
 
-    @validator("tags", pre=True, always=True)  # pylint: disable=used-before-assignment
+    @validator(
+        "tags", pre=True, always=True
+    )  # pylint: disable=used-before-assignment
     def coerce_null_tags(cls, v):  # pylint: disable=no-self-argument
         return v if v is not None else []

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -454,7 +454,9 @@ class Dataset:
             Updated list of all tags on the dataset.
         """
         if isinstance(tags, str):
-            raise TypeError("tags must be a list of strings, not a single string")
+            raise TypeError(
+                "tags must be a list of strings, not a single string"
+            )
         response = self._client.make_request(
             {"tags": tags}, f"dataset/{self.id}/tags", requests.post
         )
@@ -470,7 +472,9 @@ class Dataset:
             Updated list of remaining tags on the dataset.
         """
         if isinstance(tags, str):
-            raise TypeError("tags must be a list of strings, not a single string")
+            raise TypeError(
+                "tags must be a list of strings, not a single string"
+            )
         response = self._client.make_request(
             {"tags": tags}, f"dataset/{self.id}/tags", requests.delete
         )

--- a/nucleus/local_deduplication.py
+++ b/nucleus/local_deduplication.py
@@ -76,7 +76,7 @@ class _HammingIndex:
         self._hashes: List[int] = []
         self._candidate_marks = bytearray()
         self._indexes = [
-            [dict() for _ in range(INDEX_CHUNK_COUNT)]
+            [{} for _ in range(INDEX_CHUNK_COUNT)]
             for _ in range(PARTITION_COUNT)
         ]
 
@@ -94,9 +94,19 @@ class _HammingIndex:
         if not self._hashes:
             return None
 
+        touched_indexes = self._mark_partition_zero_candidates(phash_value)
+        if not touched_indexes:
+            return None
+
+        duplicate_index = self._find_marked_partition_one_duplicate(
+            phash_value
+        )
+        _clear_candidate_marks(self._candidate_marks, touched_indexes)
+        return duplicate_index
+
+    def _mark_partition_zero_candidates(self, phash_value: int) -> List[int]:
         touched_indexes: List[int] = []
         marks = self._candidate_marks
-
         partition_zero_chunks = _partition_chunks(phash_value, 0)
         for chunk_index, chunk_value in enumerate(partition_zero_chunks):
             index = self._indexes[0][chunk_index]
@@ -108,10 +118,12 @@ class _HammingIndex:
                     if marks[kept_index] == 0:
                         marks[kept_index] = 1
                         touched_indexes.append(kept_index)
+        return touched_indexes
 
-        if not touched_indexes:
-            return None
-
+    def _find_marked_partition_one_duplicate(
+        self, phash_value: int
+    ) -> Optional[int]:
+        marks = self._candidate_marks
         partition_one_chunks = _partition_chunks(phash_value, 1)
         for chunk_index, chunk_value in enumerate(partition_one_chunks):
             index = self._indexes[1][chunk_index]
@@ -125,11 +137,8 @@ class _HammingIndex:
                     if (
                         phash_value ^ self._hashes[kept_index]
                     ).bit_count() <= self._threshold:
-                        _clear_candidate_marks(marks, touched_indexes)
                         return kept_index
                     marks[kept_index] = 2
-
-        _clear_candidate_marks(marks, touched_indexes)
         return None
 
 

--- a/nucleus/local_deduplication.py
+++ b/nucleus/local_deduplication.py
@@ -75,12 +75,12 @@ class _HammingIndex:
         ]
         self._hashes: List[int] = []
         self._candidate_marks = bytearray()
-        self._indexes = [
+        self._indexes: List[List[dict[int, List[int]]]] = [
             [{} for _ in range(INDEX_CHUNK_COUNT)]
             for _ in range(PARTITION_COUNT)
         ]
 
-    def add(self, phash_value: int) -> None:
+    def _add(self, phash_value: int) -> None:
         kept_index = len(self._hashes)
         self._hashes.append(phash_value)
         self._candidate_marks.append(0)
@@ -90,7 +90,13 @@ class _HammingIndex:
                 index = self._indexes[partition_index][chunk_index]
                 index.setdefault(chunk_value, []).append(kept_index)
 
-    def find_duplicate_index(self, phash_value: int) -> Optional[int]:
+    def add_if_unique(self, phash_value: int) -> bool:
+        if self._find_duplicate_index(phash_value) is not None:
+            return False
+        self._add(phash_value)
+        return True
+
+    def _find_duplicate_index(self, phash_value: int) -> Optional[int]:
         if not self._hashes:
             return None
 
@@ -176,8 +182,6 @@ def deduplicate_by_phash(
 
     _validate_threshold(threshold)
     records = _normalize_records(objects, sort_key=sort_key)
-    records.sort(key=lambda record: (record.phash_value, record.stable_id))
-
     if not records:
         return LocalDeduplicationResult(
             unique=[],
@@ -189,6 +193,8 @@ def deduplicate_by_phash(
                 deduplicated_count=0,
             ),
         )
+
+    records.sort(key=lambda record: (record.phash_value, record.stable_id))
 
     if threshold == 0:
         unique_records = _deduplicate_exact(records)
@@ -305,17 +311,15 @@ def _deduplicate_with_index(
     index = _HammingIndex(threshold)
     unique_records = []
     for record in records:
-        if index.find_duplicate_index(record.phash_value) is not None:
-            continue
-        index.add(record.phash_value)
-        unique_records.append(record)
+        if index.add_if_unique(record.phash_value):
+            unique_records.append(record)
     return unique_records
 
 
 def _deduplicate_with_linear_scan(
     records: Sequence[_DeduplicationRecord[InputT]], threshold: int
 ) -> List[_DeduplicationRecord[InputT]]:
-    kept_hashes = []
+    kept_hashes: List[int] = []
     unique_records = []
     for record in records:
         is_duplicate = any(

--- a/nucleus/local_deduplication.py
+++ b/nucleus/local_deduplication.py
@@ -13,6 +13,7 @@ from .dataset_item import DatasetItem
 from .deduplication import DeduplicationStats
 
 InputT = TypeVar("InputT")
+_TieBreakKey = tuple[int, Union[int, str]]
 
 PHASH_REGEX = re.compile(r"^[01]{64}$")
 DEDUP_THRESHOLD_MIN = 0
@@ -36,18 +37,19 @@ class LocalDeduplicationResult(Generic[InputT]):
             ``DatasetItem`` objects.
         unique_dataset_items: The DatasetItem for each object in ``unique``.
         unique_reference_ids: Reference IDs for the DatasetItems in ``unique``.
+            Entries can be ``None`` if a DatasetItem has no reference ID.
         stats: Summary statistics for the run.
     """
 
     unique: List[InputT]
     unique_dataset_items: List[DatasetItem]
-    unique_reference_ids: List[str]
+    unique_reference_ids: List[Optional[str]]
     stats: DeduplicationStats
 
 
 @dataclass(slots=True)
 class _DeduplicationRecord(Generic[InputT]):
-    stable_id: str
+    stable_id: _TieBreakKey
     phash_value: int
     obj: InputT
     dataset_item: DatasetItem
@@ -194,7 +196,7 @@ def deduplicate_by_phash(
             record.dataset_item for record in unique_records
         ],
         unique_reference_ids=[
-            record.dataset_item.reference_id or "" for record in unique_records
+            record.dataset_item.reference_id for record in unique_records
         ],
         stats=DeduplicationStats(
             threshold=threshold,
@@ -238,9 +240,7 @@ def _normalize_records(
             if sort_key is not None
             else dataset_item.reference_id
         )
-        stable_id = (
-            str(tie_breaker) if tie_breaker is not None else str(ordinal)
-        )
+        stable_id = _tie_break_key(tie_breaker, ordinal)
         records.append(
             _DeduplicationRecord(
                 stable_id=stable_id,
@@ -250,6 +250,16 @@ def _normalize_records(
             )
         )
     return records
+
+
+def _tie_break_key(
+    tie_breaker: Optional[Union[str, int]], ordinal: int
+) -> _TieBreakKey:
+    if tie_breaker is None:
+        return (2, ordinal)
+    if isinstance(tie_breaker, int):
+        return (0, tie_breaker)
+    return (1, tie_breaker)
 
 
 def _extract_dataset_item(obj: InputT) -> DatasetItem:

--- a/nucleus/local_deduplication.py
+++ b/nucleus/local_deduplication.py
@@ -64,6 +64,13 @@ class _HammingIndex:
     at least one chunk within ``floor(t / 6)``. Querying both partitions and
     intersecting the candidates keeps the result exact while avoiding a full
     scan for the intended ``t <= 10`` case.
+
+    The chunk tolerance and the rotation are separate mechanisms. For
+    threshold 10, ``floor(10 / 6) == 1``, so a query chunk ``x`` probes the
+    exact bucket ``x`` plus the one-bit-away buckets ``x ^ (1 << bit_offset)``
+    inside that chunk. The eight-bit rotation does not implement that
+    tolerance; it gives a second chunk-boundary alignment so fewer false
+    candidates survive to the exact full-hash check.
     """
 
     def __init__(self, threshold: int):

--- a/nucleus/local_deduplication.py
+++ b/nucleus/local_deduplication.py
@@ -1,0 +1,349 @@
+"""Local pHash-based deduplication utilities."""
+
+from __future__ import annotations
+
+import itertools
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Generic, List, Optional, Sequence, TypeVar, Union
+
+from .constants import ITEM_KEY
+from .dataset_item import DatasetItem
+from .deduplication import DeduplicationStats
+
+InputT = TypeVar("InputT")
+
+PHASH_REGEX = re.compile(r"^[01]{64}$")
+DEDUP_THRESHOLD_MIN = 0
+DEDUP_THRESHOLD_MAX = 64
+LOCAL_INDEX_MAX_THRESHOLD = 10
+PARTITION_COUNT = 2
+INDEX_CHUNK_BITS = (11, 11, 11, 11, 10, 10)
+INDEX_CHUNK_COUNT = len(INDEX_CHUNK_BITS)
+PHASH_VALUE_MASK = (1 << 64) - 1
+ROTATED_PARTITION_BITS = 8
+
+
+@dataclass
+class LocalDeduplicationResult(Generic[InputT]):
+    """Output of a local pHash deduplication run.
+
+    Attributes:
+        unique: Input objects that survived deduplication. If you passed rows
+            from ``items_and_annotation_generator()``, this contains those same
+            row dictionaries. If you passed ``DatasetItem`` objects, it contains
+            ``DatasetItem`` objects.
+        unique_dataset_items: The DatasetItem for each object in ``unique``.
+        unique_reference_ids: Reference IDs for the DatasetItems in ``unique``.
+        stats: Summary statistics for the run.
+    """
+
+    unique: List[InputT]
+    unique_dataset_items: List[DatasetItem]
+    unique_reference_ids: List[str]
+    stats: DeduplicationStats
+
+
+@dataclass(slots=True)
+class _DeduplicationRecord(Generic[InputT]):
+    stable_id: str
+    phash_value: int
+    obj: InputT
+    dataset_item: DatasetItem
+
+
+class _HammingIndex:
+    """Exact Hamming near-neighbor index for 64-bit hashes.
+
+    The first partition splits the pHash into six contiguous chunks.
+    The second partition rotates the pHash by eight bits, then applies the same
+    chunking. If two hashes are within threshold ``t``, then each partition has
+    at least one chunk within ``floor(t / 6)``. Querying both partitions and
+    intersecting the candidates keeps the result exact while avoiding a full
+    scan for the intended ``t <= 10`` case.
+    """
+
+    def __init__(self, threshold: int):
+        self._threshold = threshold
+        self._chunk_radius = threshold // INDEX_CHUNK_COUNT
+        self._variant_masks_by_chunk = [
+            _variant_masks(self._chunk_radius, chunk_bits)
+            for chunk_bits in INDEX_CHUNK_BITS
+        ]
+        self._hashes: List[int] = []
+        self._candidate_marks = bytearray()
+        self._indexes = [
+            [dict() for _ in range(INDEX_CHUNK_COUNT)]
+            for _ in range(PARTITION_COUNT)
+        ]
+
+    def add(self, phash_value: int) -> None:
+        kept_index = len(self._hashes)
+        self._hashes.append(phash_value)
+        self._candidate_marks.append(0)
+        for partition_index in range(PARTITION_COUNT):
+            chunks = _partition_chunks(phash_value, partition_index)
+            for chunk_index, chunk_value in enumerate(chunks):
+                index = self._indexes[partition_index][chunk_index]
+                index.setdefault(chunk_value, []).append(kept_index)
+
+    def find_duplicate_index(self, phash_value: int) -> Optional[int]:
+        if not self._hashes:
+            return None
+
+        touched_indexes: List[int] = []
+        marks = self._candidate_marks
+
+        partition_zero_chunks = _partition_chunks(phash_value, 0)
+        for chunk_index, chunk_value in enumerate(partition_zero_chunks):
+            index = self._indexes[0][chunk_index]
+            for mask in self._variant_masks_by_chunk[chunk_index]:
+                bucket = index.get(chunk_value ^ mask)
+                if bucket is None:
+                    continue
+                for kept_index in bucket:
+                    if marks[kept_index] == 0:
+                        marks[kept_index] = 1
+                        touched_indexes.append(kept_index)
+
+        if not touched_indexes:
+            return None
+
+        partition_one_chunks = _partition_chunks(phash_value, 1)
+        for chunk_index, chunk_value in enumerate(partition_one_chunks):
+            index = self._indexes[1][chunk_index]
+            for mask in self._variant_masks_by_chunk[chunk_index]:
+                bucket = index.get(chunk_value ^ mask)
+                if bucket is None:
+                    continue
+                for kept_index in bucket:
+                    if marks[kept_index] != 1:
+                        continue
+                    if (
+                        phash_value ^ self._hashes[kept_index]
+                    ).bit_count() <= self._threshold:
+                        _clear_candidate_marks(marks, touched_indexes)
+                        return kept_index
+                    marks[kept_index] = 2
+
+        _clear_candidate_marks(marks, touched_indexes)
+        return None
+
+
+def deduplicate_by_phash(
+    objects: Iterable[InputT],
+    threshold: int,
+    *,
+    sort_key: Optional[Callable[[InputT], Union[str, int]]] = None,
+) -> LocalDeduplicationResult[InputT]:
+    """Deduplicate local DatasetItems or item/annotation rows by pHash.
+
+    This utility does not call the Nucleus API and does not require an API key.
+    It accepts either ``DatasetItem`` objects or rows returned from
+    ``items_and_annotation_generator()`` / ``items_and_annotations()`` where
+    the row has an ``"item"`` key containing a ``DatasetItem``. The returned
+    ``unique`` list contains the same kind of objects that were passed in.
+
+    Args:
+        objects: DatasetItems or item/annotation rows to deduplicate.
+        threshold: Hamming distance threshold (0-64). Lower = stricter.
+            ``0`` deduplicates exact pHash matches only.
+        sort_key: Optional stable tie-break key used after pHash sorting. When
+            omitted, DatasetItem.reference_id is used.
+
+    Returns:
+        LocalDeduplicationResult containing the surviving input objects and
+        summary statistics.
+
+    Raises:
+        TypeError: If an input object is neither a DatasetItem nor a mapping
+            with an ``"item"`` DatasetItem.
+        ValueError: If threshold is invalid, or any selected DatasetItem is
+            missing a 64-character binary pHash.
+    """
+
+    _validate_threshold(threshold)
+    records = _normalize_records(objects, sort_key=sort_key)
+    records.sort(key=lambda record: (record.phash_value, record.stable_id))
+
+    if not records:
+        return LocalDeduplicationResult(
+            unique=[],
+            unique_dataset_items=[],
+            unique_reference_ids=[],
+            stats=DeduplicationStats(
+                threshold=threshold,
+                original_count=0,
+                deduplicated_count=0,
+            ),
+        )
+
+    if threshold == 0:
+        unique_records = _deduplicate_exact(records)
+    elif threshold == DEDUP_THRESHOLD_MAX:
+        unique_records = [records[0]]
+    elif threshold <= LOCAL_INDEX_MAX_THRESHOLD:
+        unique_records = _deduplicate_with_index(records, threshold)
+    else:
+        unique_records = _deduplicate_with_linear_scan(records, threshold)
+
+    return LocalDeduplicationResult(
+        unique=[record.obj for record in unique_records],
+        unique_dataset_items=[
+            record.dataset_item for record in unique_records
+        ],
+        unique_reference_ids=[
+            record.dataset_item.reference_id or "" for record in unique_records
+        ],
+        stats=DeduplicationStats(
+            threshold=threshold,
+            original_count=len(records),
+            deduplicated_count=len(unique_records),
+        ),
+    )
+
+
+def _validate_threshold(threshold: int) -> None:
+    if (
+        not isinstance(threshold, int)
+        or isinstance(threshold, bool)
+        or threshold < DEDUP_THRESHOLD_MIN
+        or threshold > DEDUP_THRESHOLD_MAX
+    ):
+        raise ValueError(
+            "threshold must be an integer between 0 and 64 (inclusive)"
+        )
+
+
+def _normalize_records(
+    objects: Iterable[InputT],
+    *,
+    sort_key: Optional[Callable[[InputT], Union[str, int]]],
+) -> List[_DeduplicationRecord[InputT]]:
+    records = []
+    for ordinal, obj in enumerate(objects):
+        dataset_item = _extract_dataset_item(obj)
+        phash = dataset_item.phash
+        if phash is None or not PHASH_REGEX.fullmatch(phash):
+            ref_id = dataset_item.reference_id
+            ref_msg = f" with reference_id {ref_id!r}" if ref_id else ""
+            raise ValueError(
+                "All DatasetItems must have a 64-character binary pHash. "
+                f"Found missing or malformed pHash on item{ref_msg}."
+            )
+
+        tie_breaker = (
+            sort_key(obj)
+            if sort_key is not None
+            else dataset_item.reference_id
+        )
+        stable_id = (
+            str(tie_breaker) if tie_breaker is not None else str(ordinal)
+        )
+        records.append(
+            _DeduplicationRecord(
+                stable_id=stable_id,
+                phash_value=int(phash, 2),
+                obj=obj,
+                dataset_item=dataset_item,
+            )
+        )
+    return records
+
+
+def _extract_dataset_item(obj: InputT) -> DatasetItem:
+    if isinstance(obj, DatasetItem):
+        return obj
+
+    if isinstance(obj, Mapping):
+        item = obj.get(ITEM_KEY)
+        if isinstance(item, DatasetItem):
+            return item
+
+    raise TypeError(
+        "Expected each object to be a DatasetItem or a mapping with an "
+        f"{ITEM_KEY!r} DatasetItem."
+    )
+
+
+def _deduplicate_exact(
+    records: Sequence[_DeduplicationRecord[InputT]],
+) -> List[_DeduplicationRecord[InputT]]:
+    seen_phashes = set()
+    unique_records = []
+    for record in records:
+        if record.phash_value in seen_phashes:
+            continue
+        seen_phashes.add(record.phash_value)
+        unique_records.append(record)
+    return unique_records
+
+
+def _deduplicate_with_index(
+    records: Sequence[_DeduplicationRecord[InputT]], threshold: int
+) -> List[_DeduplicationRecord[InputT]]:
+    index = _HammingIndex(threshold)
+    unique_records = []
+    for record in records:
+        if index.find_duplicate_index(record.phash_value) is not None:
+            continue
+        index.add(record.phash_value)
+        unique_records.append(record)
+    return unique_records
+
+
+def _deduplicate_with_linear_scan(
+    records: Sequence[_DeduplicationRecord[InputT]], threshold: int
+) -> List[_DeduplicationRecord[InputT]]:
+    kept_hashes = []
+    unique_records = []
+    for record in records:
+        is_duplicate = any(
+            (record.phash_value ^ kept_hash).bit_count() <= threshold
+            for kept_hash in kept_hashes
+        )
+        if is_duplicate:
+            continue
+        kept_hashes.append(record.phash_value)
+        unique_records.append(record)
+    return unique_records
+
+
+def _partition_chunks(
+    phash_value: int, partition_index: int
+) -> tuple[int, ...]:
+    if partition_index == 1:
+        phash_value = _rotate_right_64(phash_value, ROTATED_PARTITION_BITS)
+
+    chunks = []
+    shift = 64
+    for chunk_bits in INDEX_CHUNK_BITS:
+        shift -= chunk_bits
+        chunks.append((phash_value >> shift) & ((1 << chunk_bits) - 1))
+    return tuple(chunks)
+
+
+def _rotate_right_64(phash_value: int, bits: int) -> int:
+    return (
+        (phash_value >> bits) | (phash_value << (64 - bits))
+    ) & PHASH_VALUE_MASK
+
+
+def _clear_candidate_marks(
+    marks: bytearray, touched_indexes: List[int]
+) -> None:
+    for kept_index in touched_indexes:
+        marks[kept_index] = 0
+
+
+def _variant_masks(radius: int, chunk_bits: int) -> List[int]:
+    masks = [0]
+    bit_indexes = range(chunk_bits)
+    for distance in range(1, radius + 1):
+        for positions in itertools.combinations(bit_indexes, distance):
+            mask = 0
+            for position in positions:
+                mask |= 1 << position
+            masks.append(mask)
+    return masks

--- a/tests/test_local_deduplication.py
+++ b/tests/test_local_deduplication.py
@@ -1,5 +1,6 @@
-import pytest
 import random
+
+import pytest
 
 from nucleus import DatasetItem, deduplicate_by_phash
 from nucleus.local_deduplication import LocalDeduplicationResult

--- a/tests/test_local_deduplication.py
+++ b/tests/test_local_deduplication.py
@@ -1,0 +1,173 @@
+import pytest
+import random
+
+from nucleus import DatasetItem, deduplicate_by_phash
+from nucleus.local_deduplication import LocalDeduplicationResult
+
+
+def _item(reference_id, phash):
+    return DatasetItem(
+        image_location=f"https://example.com/{reference_id}.jpg",
+        reference_id=reference_id,
+        phash=phash,
+    )
+
+
+def _row(reference_id, phash):
+    return {
+        "item": _item(reference_id, phash),
+        "annotations": {"box": [f"annotation-{reference_id}"]},
+    }
+
+
+def _flip_bits(phash, indexes):
+    bits = list(phash)
+    for index in indexes:
+        bits[index] = "1" if bits[index] == "0" else "0"
+    return "".join(bits)
+
+
+def test_deduplicate_by_phash_preserves_generator_rows():
+    base = "0" * 64
+    near = _flip_bits(base, [63])
+    far = "1" * 64
+    row_b = _row("b", near)
+    row_a = _row("a", base)
+    row_c = _row("c", far)
+
+    result = deduplicate_by_phash([row_b, row_a, row_c], threshold=1)
+
+    assert isinstance(result, LocalDeduplicationResult)
+    assert result.unique == [row_a, row_c]
+    assert result.unique_dataset_items == [row_a["item"], row_c["item"]]
+    assert result.unique_reference_ids == ["a", "c"]
+    assert result.stats.threshold == 1
+    assert result.stats.original_count == 3
+    assert result.stats.deduplicated_count == 2
+
+
+def test_deduplicate_by_phash_accepts_dataset_items():
+    base = "0" * 64
+    duplicate = "0" * 64
+    distinct = _flip_bits(base, [63])
+    item_a = _item("a", base)
+    item_b = _item("b", duplicate)
+    item_c = _item("c", distinct)
+
+    result = deduplicate_by_phash([item_b, item_c, item_a], threshold=0)
+
+    assert result.unique == [item_a, item_c]
+    assert result.unique_dataset_items == [item_a, item_c]
+    assert result.unique_reference_ids == ["a", "c"]
+    assert result.stats.original_count == 3
+    assert result.stats.deduplicated_count == 2
+
+
+def test_deduplicate_by_phash_threshold_ten_uses_hamming_distance():
+    base = "0" * 64
+    distance_ten = _flip_bits(base, range(10))
+    distance_eleven = _flip_bits(base, range(11))
+    row_a = _row("a", base)
+    row_b = _row("b", distance_ten)
+    row_c = _row("c", distance_eleven)
+
+    result = deduplicate_by_phash([row_c, row_b, row_a], threshold=10)
+
+    assert result.unique == [row_a, row_c]
+    assert result.unique_reference_ids == ["a", "c"]
+    assert result.stats.deduplicated_count == 2
+
+
+@pytest.mark.parametrize("threshold", [1, 5, 10])
+def test_deduplicate_by_phash_matches_linear_baseline(threshold):
+    random.seed(123)
+    rows = [
+        _row(f"item_{i:03d}", f"{random.getrandbits(64):064b}")
+        for i in range(200)
+    ]
+
+    baseline_unique_reference_ids = []
+    baseline_kept_phashes = []
+    for row in sorted(
+        rows,
+        key=lambda candidate: (
+            candidate["item"].phash,
+            candidate["item"].reference_id,
+        ),
+    ):
+        phash_value = int(row["item"].phash, 2)
+        if any(
+            (phash_value ^ kept_phash).bit_count() <= threshold
+            for kept_phash in baseline_kept_phashes
+        ):
+            continue
+        baseline_kept_phashes.append(phash_value)
+        baseline_unique_reference_ids.append(row["item"].reference_id)
+
+    result = deduplicate_by_phash(rows, threshold=threshold)
+
+    assert result.unique_reference_ids == baseline_unique_reference_ids
+
+
+def test_deduplicate_by_phash_threshold_sixty_four_keeps_one_item():
+    row_a = _row("a", "1" * 64)
+    row_b = _row("b", "0" * 64)
+    row_c = _row("c", _flip_bits("0" * 64, [63]))
+
+    result = deduplicate_by_phash([row_a, row_c, row_b], threshold=64)
+
+    assert result.unique == [row_b]
+    assert result.unique_reference_ids == ["b"]
+    assert result.stats.original_count == 3
+    assert result.stats.deduplicated_count == 1
+
+
+def test_deduplicate_by_phash_empty_input_returns_empty_result():
+    result = deduplicate_by_phash([], threshold=10)
+
+    assert result.unique == []
+    assert result.unique_dataset_items == []
+    assert result.unique_reference_ids == []
+    assert result.stats.threshold == 10
+    assert result.stats.original_count == 0
+    assert result.stats.deduplicated_count == 0
+
+
+@pytest.mark.parametrize("threshold", [-1, 65, 1.5, True])
+def test_deduplicate_by_phash_rejects_invalid_threshold(threshold):
+    with pytest.raises(
+        ValueError,
+        match="threshold must be an integer between 0 and 64",
+    ):
+        deduplicate_by_phash([], threshold=threshold)
+
+
+@pytest.mark.parametrize("phash", [None, "", "0" * 63, "0" * 65, "x" * 64])
+def test_deduplicate_by_phash_rejects_missing_or_malformed_phash(phash):
+    with pytest.raises(
+        ValueError,
+        match="All DatasetItems must have a 64-character binary pHash",
+    ):
+        deduplicate_by_phash([_item("bad", phash)], threshold=10)
+
+
+def test_deduplicate_by_phash_rejects_unsupported_input_shape():
+    with pytest.raises(
+        TypeError,
+        match="Expected each object to be a DatasetItem",
+    ):
+        deduplicate_by_phash([{"not_item": _item("a", "0" * 64)}], threshold=0)
+
+
+def test_deduplicate_by_phash_uses_custom_sort_key():
+    row_a = _row("a", "0" * 64)
+    row_b = _row("b", "0" * 64)
+
+    result = deduplicate_by_phash(
+        [row_a, row_b],
+        threshold=0,
+        sort_key=lambda row: 0 if row["item"].reference_id == "b" else 1,
+    )
+
+    assert result.unique == [row_b]
+    assert result.unique_reference_ids == ["b"]

--- a/tests/test_local_deduplication.py
+++ b/tests/test_local_deduplication.py
@@ -20,6 +20,13 @@ def _row(reference_id, phash):
     }
 
 
+def _item_without_reference_id(phash):
+    item = DatasetItem.__new__(DatasetItem)
+    item.reference_id = None
+    item.phash = phash
+    return item
+
+
 def _flip_bits(phash, indexes):
     bits = list(phash)
     for index in indexes:
@@ -78,7 +85,7 @@ def test_deduplicate_by_phash_threshold_ten_uses_hamming_distance():
     assert result.stats.deduplicated_count == 2
 
 
-@pytest.mark.parametrize("threshold", [1, 5, 10])
+@pytest.mark.parametrize("threshold", [1, 5, 10, 11, 20])
 def test_deduplicate_by_phash_matches_linear_baseline(threshold):
     random.seed(123)
     rows = [
@@ -171,3 +178,47 @@ def test_deduplicate_by_phash_uses_custom_sort_key():
 
     assert result.unique == [row_b]
     assert result.unique_reference_ids == ["b"]
+
+
+def test_deduplicate_by_phash_sorts_integer_sort_key_numerically():
+    row_a = _row("a", "0" * 64)
+    row_b = _row("b", "0" * 64)
+
+    result = deduplicate_by_phash(
+        [row_a, row_b],
+        threshold=0,
+        sort_key=lambda row: 10 if row["item"].reference_id == "a" else 9,
+    )
+
+    assert result.unique == [row_b]
+    assert result.unique_reference_ids == ["b"]
+
+
+def test_deduplicate_by_phash_preserves_ordinal_fallback_order():
+    rows = [
+        _row(
+            f"item_{index}", "1" * 64 if index in (2, 10) else f"{index:064b}"
+        )
+        for index in range(11)
+    ]
+
+    result = deduplicate_by_phash(
+        rows,
+        threshold=0,
+        sort_key=lambda row: None,
+    )
+
+    assert "item_2" in result.unique_reference_ids
+    assert "item_10" not in result.unique_reference_ids
+
+
+def test_deduplicate_by_phash_preserves_missing_reference_ids():
+    item_without_reference_id = _item_without_reference_id("0" * 64)
+    item_with_reference_id = _item("b", "1" * 64)
+
+    result = deduplicate_by_phash(
+        [item_with_reference_id, item_without_reference_id],
+        threshold=0,
+    )
+
+    assert result.unique_reference_ids == [None, "b"]


### PR DESCRIPTION
## Summary

Adds a local pHash-based deduplication utility for Nucleus SDK users who already have a large list of `DatasetItem` objects or rows from `items_and_annotation_generator()`.

- Exposes `nucleus.deduplicate_by_phash(...)` and `LocalDeduplicationResult`.
- Accepts either `DatasetItem` objects or generator rows with an `"item"` `DatasetItem`.
- Preserves Nucleus threshold semantics for `0..64`.
- Uses fast exact-pHash handling for `threshold == 0`, a single-item fast path for `threshold == 64`, an exact chunked Hamming-neighbor index for `1 <= threshold <= 10`, and a linear exact fallback for thresholds above 10.
- Returns the surviving original objects, surviving dataset items, reference IDs, and `DeduplicationStats`.

## Writeup: Local pHash Deduplication

### Baseline Problem

The logical algorithm is greedy deduplication. Sort rows deterministically, then keep a candidate only if no previously kept pHash is within the requested Hamming distance threshold.

```python
kept = []
for row in sorted_rows:
    if not any(hamming(row.phash, kept_hash) <= threshold for kept_hash in kept):
        kept.append(row)
```

This is exact but effectively quadratic for mostly distinct inputs, because each new candidate may scan every pHash kept so far.

### Technique 1: Fail Fast and Normalize Once

Before the dedup pass starts, each input is normalized into an internal record with the original object, its `DatasetItem`, a stable tie-break ID, and the pHash parsed as a 64-bit integer. Threshold validation and pHash validation happen up front, so a long local run fails before doing expensive work if any pHash is missing or malformed.

### Technique 2: Integer pHashes and Integer Hamming Distance

Backend pHashes arrive as 64-character binary strings. The utility parses each pHash once with `int(phash, 2)`, then computes Hamming distance with:

```python
(candidate_phash_value ^ kept_phash_value).bit_count()
```

This avoids per-character string comparison and enables sorting by `(phash_value, stable_id)`.

### Technique 3: Threshold-Specific Fast Paths

| Threshold case | Implementation | Reason |
|---|---|---|
| `threshold == 0` | Keep the first row per exact integer pHash. | Hamming distance must be exactly zero, so only exact pHash duplicates are removed. |
| `threshold == 64` | Keep the first sorted item. | Any two 64-bit hashes are within distance 64. |
| `1 <= threshold <= 10` | Use the exact chunked Hamming index. | This is the expected practical range and keeps chunk radius small. |
| `threshold > 10` | Use a linear greedy scan. | Larger radii make chunk neighborhoods dense enough that the index becomes less attractive. |

### Technique 4: Chunking With the Pigeonhole Principle

The accelerated path splits each 64-bit pHash into six chunks:

```python
INDEX_CHUNK_BITS = (11, 11, 11, 11, 10, 10)
```

For threshold `t`, the per-chunk radius is `floor(t / 6)`. If two pHashes have total Hamming distance at most `t`, at least one of the six chunks must be within that per-chunk radius. Otherwise every chunk would exceed the radius, forcing the total Hamming distance above `t`.

For `threshold=10`, the per-chunk radius is `1`. One partition performs `4 * 12 + 2 * 11 = 70` dictionary lookups: each 11-bit chunk checks the exact value plus 11 one-bit variants, and each 10-bit chunk checks the exact value plus 10 one-bit variants.

### Technique 5: Two Partitions With Cheap Rotation

A single chunk partition can produce many false candidates. The utility uses two exact partitions:

- Partition 0 splits the original 64-bit pHash into six contiguous chunks.
- Partition 1 rotates the pHash right by 8 bits, then splits into the same chunk widths.

The rotation is cheap:

```python
((phash_value >> 8) | (phash_value << 56)) & ((1 << 64) - 1)
```

The pigeonhole argument applies independently to both partitions, so true duplicates cannot be missed. A candidate must be found by both partitions before the exact 64-bit Hamming check runs.

### Technique 6: Reusable Candidate Marks Instead of Set Intersections

The permanent state remains simple: `kept_hashes` stores pHashes that survived deduplication, and chunk dictionaries point chunk values back to positions in `kept_hashes`. Those positions are called kept indexes.

Conceptually, each query intersects two candidate sets:

```python
partition_0_candidates = {17, 31, 44, 91, ...}
partition_1_candidates = {3, 17, 88, 91, ...}
intersection = {17, 91, ...}
```

The first implementation literally allocated Python `set()` objects and intersected them per candidate. The current implementation uses a reusable `bytearray` with one mark byte per kept pHash:

```python
# Partition 0
candidate_marks[17] = 1
candidate_marks[31] = 1
candidate_marks[44] = 1
candidate_marks[91] = 1

# Partition 1
if candidate_marks[17] == 1: exact_check(17)
if candidate_marks[88] == 1: exact_check(88)  # skipped; mark is zero
if candidate_marks[91] == 1: exact_check(91)
```

After each query, only touched indexes are cleared. This computes the same intersection while avoiding large temporary set allocations.

## Real Dataset Profile

I profiled this on an internal real production dataset with `278,587` rows. Because this repository is public, the dataset identifier and name are intentionally omitted from the PR body. The API key was not included in the report or the PR.

The profiler exported rows with `items_and_annotation_generator()`, held the exported rows in memory, and then timed only `deduplicate_by_phash(...)` so export/API time and local dedup CPU time are separated.

| Input rows | Export time | Missing pHashes | Malformed pHashes | Duplicate reference IDs |
|---:|---:|---:|---:|---:|
| 278,587 | 127.04s | 0 | 0 | 0 |

Local dedup timing only:

| Threshold | Kept | Removed | Removed % | Dedup time | Peak tracemalloc | Process max RSS |
|---:|---:|---:|---:|---:|---:|---:|
| 0 | 277,164 | 1,423 | 0.51% | 1.86s | 47.90 MB | 1.41 GB |
| 5 | 252,084 | 26,503 | 9.51% | 50.79s | 66.94 MB | 1.46 GB |
| 10 | 194,776 | 83,811 | 30.08% | 396.58s | 59.02 MB | 1.46 GB |

The practical read: the expensive exact local dedup case took about `6m 36.6s` for `278,587` real rows. If a user exports the dataset and runs threshold 10, the observed end-to-end time for this dataset would be roughly `127.04s + 396.58s = 523.62s`, or about `8m 43.6s`.

That is a reasonable runtime for an offline local utility, especially because the implementation is deterministic, exact, requires no server-side job, and validates pHashes before starting the expensive pass.

## Validation

- `NUCLEUS_PYTEST_API_KEY=dummy .venv/bin/python -m pytest tests/test_local_deduplication.py -q`
- Real dataset profile using the local SDK editable install in `.venv`.

Focused tests cover row preservation, `DatasetItem` inputs, threshold 0, threshold 64, invalid thresholds, malformed pHashes, unsupported input shapes, custom sort keys, and parity against a simple linear baseline for thresholds 1, 5, and 10.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fully offline `deduplicate_by_phash()` utility and `LocalDeduplicationResult` to the Nucleus SDK. It requires no API key, accepts `DatasetItem` objects or generator rows, and dispatches to an exact-match path (threshold 0), a two-partition chunked Hamming index (thresholds 1–10), a linear greedy fallback (thresholds 11–63), or a keep-one path (threshold 64).

- **`nucleus/local_deduplication.py`**: New module implementing the full pipeline — pHash validation, stable-id tie-breaking via `_tie_break_key`, the `_HammingIndex` with pigeonhole-based candidate filtering and reusable `bytearray` marks, and the three dedup paths.
- **`tests/test_local_deduplication.py`**: Covers all dispatch paths, custom/integer/None sort keys, ordinal fallback, missing reference IDs, and parity against a linear baseline for thresholds 1, 5, 10, 11, and 20.
- **`nucleus/__init__.py`**: Re-exports `deduplicate_by_phash` and `LocalDeduplicationResult` from the public namespace.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new utility is fully offline and additive, with no changes to existing API paths or data models.

The algorithm is provably correct: the pigeonhole argument holds for both partitions independently, the mark-based candidate intersection correctly resets state after every query, and all three dedup paths produce results consistent with the linear baseline. The previous issues around string-encoded sort keys and empty-string reference IDs are both resolved. The type annotation for sort_key's return type is the only gap.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| nucleus/local_deduplication.py | New file: implements the full local pHash dedup pipeline — exact path, two-partition Hamming index, and linear fallback — with correct mark-based candidate intersection and clean threshold dispatch. |
| tests/test_local_deduplication.py | New file: comprehensive test suite covering all fast-paths, sort-key variants, error cases, and a parity baseline for thresholds 1, 5, 10, 11, and 20 (index and linear-scan paths). |
| nucleus/__init__.py | Exports LocalDeduplicationResult and deduplicate_by_phash from the public nucleus namespace. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deduplicate_by_phash] --> B[_validate_threshold]
    B --> C[_normalize_records]
    C --> D{empty?}
    D -- yes --> E[return empty result]
    D -- no --> F[sort by phash_value, stable_id]
    F --> G{threshold?}
    G -- 0 --> H[_deduplicate_exact]
    G -- 64 --> I[keep records 0]
    G -- 1..10 --> J[_deduplicate_with_index]
    G -- 11..63 --> K[_deduplicate_with_linear_scan]
    H --> L[LocalDeduplicationResult]
    I --> L
    J --> L
    K --> L
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Anucleus%2Flocal_deduplication.py%3A162%0AThe%20%60sort_key%60%20callable's%20return%20type%20is%20annotated%20as%20%60Union%5Bstr%2C%20int%5D%60%2C%20but%20%60_tie_break_key%60%20explicitly%20handles%20a%20%60None%60%20return%2C%20and%20%60test_deduplicate_by_phash_preserves_ordinal_fallback_order%60%20relies%20on%20it%20with%20%60sort_key%3Dlambda%20row%3A%20None%60.%20A%20caller%20reading%20the%20signature%20has%20no%20indication%20that%20returning%20%60None%60%20is%20valid%20and%20falls%20back%20to%20ordinal%20ordering%20%E2%80%94%20the%20annotation%20should%20reflect%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20sort_key%3A%20Optional%5BCallable%5B%5BInputT%5D%2C%20Optional%5BUnion%5Bstr%2C%20int%5D%5D%5D%5D%20%3D%20None%2C%0A%60%60%60%0A%0A&pr=462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Anucleus%2Flocal_deduplication.py%3A162%0AThe%20%60sort_key%60%20callable's%20return%20type%20is%20annotated%20as%20%60Union%5Bstr%2C%20int%5D%60%2C%20but%20%60_tie_break_key%60%20explicitly%20handles%20a%20%60None%60%20return%2C%20and%20%60test_deduplicate_by_phash_preserves_ordinal_fallback_order%60%20relies%20on%20it%20with%20%60sort_key%3Dlambda%20row%3A%20None%60.%20A%20caller%20reading%20the%20signature%20has%20no%20indication%20that%20returning%20%60None%60%20is%20valid%20and%20falls%20back%20to%20ordinal%20ordering%20%E2%80%94%20the%20annotation%20should%20reflect%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20sort_key%3A%20Optional%5BCallable%5B%5BInputT%5D%2C%20Optional%5BUnion%5Bstr%2C%20int%5D%5D%5D%5D%20%3D%20None%2C%0A%60%60%60%0A%0A&repo=scaleapi%2Fnucleus-python-client&pr=462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fnucleus-python-client%22%20on%20the%20existing%20branch%20%22codex%2Flocal-phash-dedup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Flocal-phash-dedup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Anucleus%2Flocal_deduplication.py%3A162%0AThe%20%60sort_key%60%20callable's%20return%20type%20is%20annotated%20as%20%60Union%5Bstr%2C%20int%5D%60%2C%20but%20%60_tie_break_key%60%20explicitly%20handles%20a%20%60None%60%20return%2C%20and%20%60test_deduplicate_by_phash_preserves_ordinal_fallback_order%60%20relies%20on%20it%20with%20%60sort_key%3Dlambda%20row%3A%20None%60.%20A%20caller%20reading%20the%20signature%20has%20no%20indication%20that%20returning%20%60None%60%20is%20valid%20and%20falls%20back%20to%20ordinal%20ordering%20%E2%80%94%20the%20annotation%20should%20reflect%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20sort_key%3A%20Optional%5BCallable%5B%5BInputT%5D%2C%20Optional%5BUnion%5Bstr%2C%20int%5D%5D%5D%5D%20%3D%20None%2C%0A%60%60%60%0A%0A&repo=scaleapi%2Fnucleus-python-client&pr=462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
nucleus/local_deduplication.py:162
The `sort_key` callable's return type is annotated as `Union[str, int]`, but `_tie_break_key` explicitly handles a `None` return, and `test_deduplicate_by_phash_preserves_ordinal_fallback_order` relies on it with `sort_key=lambda row: None`. A caller reading the signature has no indication that returning `None` is valid and falls back to ordinal ordering — the annotation should reflect this.

```suggestion
    sort_key: Optional[Callable[[InputT], Optional[Union[str, int]]]] = None,
```

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Run pre-commit formatting"](https://github.com/scaleapi/nucleus-python-client/commit/a0409c02767e13f2a5d8a41a25e381c7089585e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35648218)</sub>

<!-- /greptile_comment -->