### PR TITLE
Release v0.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.4](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.18.4) - 2026-06-08
+
+### Added
+- `deduplicate_by_phash` local utility for deduplicating `DatasetItem` objects or `items_and_annotation_generator()` rows by `DatasetItem.phash` without making API calls. The utility supports Hamming-distance thresholds from 0 to 64 and returns the surviving input objects, their `DatasetItem`s, reference IDs, and `DeduplicationStats`.
+
 ## [0.18.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.18.3) - 2026-05-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.18.3"
+version = "0.18.4"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
## Summary

Bump `scale-nucleus` from `0.18.3` to `0.18.4` and add a `CHANGELOG.md` entry for the local pHash deduplication utility merged in #462.

This follows the prior release metadata pattern from #461 and #455: update the single Poetry version source in `pyproject.toml`, then prepend the matching Keep-a-Changelog entry.

## Release notes

- Adds release metadata for `deduplicate_by_phash`, which deduplicates `DatasetItem` objects or `items_and_annotation_generator()` rows by local pHash without API calls.
- Documents threshold support and the returned result fields (`unique`, `unique_dataset_items`, `unique_reference_ids`, and `DeduplicationStats`).

## Validation

- `poetry run pre-commit run --all-files`
- `poetry build`
- Verified `scale-nucleus` latest on PyPI is currently `0.18.3`; `v0.18.4` is not present in local tags.

After this merges, publishing should be triggered by tagging the merged commit as `v0.18.4`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the `scale-nucleus` package version from `0.18.3` to `0.18.4` and prepends the corresponding Keep-a-Changelog entry for the `deduplicate_by_phash` local deduplication utility introduced in #462.

- `pyproject.toml`: single-line version bump in `[tool.poetry]`.
- `CHANGELOG.md`: new `## [0.18.4]` section documenting `deduplicate_by_phash`, its threshold support, and returned result fields, following the same format as prior release entries.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only release metadata is touched; no logic, APIs, or runtime behaviour is modified.

The change is limited to a one-line version bump in `pyproject.toml` and a new changelog entry in `CHANGELOG.md`. No source code, tests, or dependencies are altered, and both files follow the established pattern from previous releases.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Prepends a new v0.18.4 entry documenting the `deduplicate_by_phash` utility; format and date are consistent with prior entries. |
| pyproject.toml | Single-line version bump from `0.18.3` to `0.18.4` in the `[tool.poetry]` section; no other fields changed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #463 merged to master] --> B[Tag merged commit as v0.18.4]
    B --> C[CI/CD publish triggered]
    C --> D[poetry build]
    D --> E[Publish scale-nucleus==0.18.4 to PyPI]
    E --> F[Users can pip install scale-nucleus==0.18.4]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump version for local pHash dedup relea..."](https://github.com/scaleapi/nucleus-python-client/commit/823a40bac969d4298ad01ae7b7008dddffc3f074) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36221454)</sub>

<!-- /greptile_comment -->