### PR TITLE
feat(nucleus): Expose dataset_item_id on exported items, annotations and predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.20.1) - 2026-08-14
+## [0.20.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.20.1) - 2026-08-18
 
 ### Added
 - **`dataset_item_id` on exported items and objects.** Batch exports now carry the Nucleus-internal dataset item id (`di_*`) everywhere `reference_id` already appeared: on `DatasetItem`, and on every exported annotation and prediction (`box`, `line`, `polygon`, `keypoints`, `cuboid`, `category`, `multicategory`, `segmentation`). Video/scene exports carry it on each track frame. Previously only `reference_id` was returned, so keying predictions back to items required a second lookup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.20.1) - 2026-08-14
+
+### Added
+- **`dataset_item_id` on exported items and objects.** Batch exports now carry the Nucleus-internal dataset item id (`di_*`) everywhere `reference_id` already appeared: on `DatasetItem`, and on every exported annotation and prediction (`box`, `line`, `polygon`, `keypoints`, `cuboid`, `category`, `multicategory`, `segmentation`). Video/scene exports carry it on each track frame. Previously only `reference_id` was returned, so keying predictions back to items required a second lookup.
+
+  The field is server-assigned and read-only: it is populated by `from_json`, left `None` on objects you construct locally, excluded from `__eq__`, and never sent in `to_payload`. Exports from an older backend that does not return it simply leave it `None`.
+
 ## [0.20.0](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.20.0) - 2026-08-11
 
 ### Added

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -51,6 +51,20 @@ from .constants import (
 # pylint: disable=C0302
 
 
+def _server_assigned_id_field():
+    """Dataclass field for the Nucleus-internal dataset item id (``di_*``) of the
+    item this object sits on.
+
+    Server-assigned and read-only: populated on objects returned by the API,
+    ``None`` on ones you construct locally to upload, and never sent in
+    ``to_payload``. Excluded from ``__eq__`` so a locally-built object still
+    compares equal to its round-tripped self (same reason as
+    ``DatasetItem.phash``).
+    """
+    # pylint: disable=invalid-field-call  # returned into a dataclass body below
+    return field(default=None, repr=False, compare=False)
+
+
 class Annotation:
     """Internal base class, not to be used directly.
 
@@ -59,8 +73,8 @@ class Annotation:
     """
 
     reference_id: str
-    # Set on every subclass so callers can read it off the base type. See the note on
-    # BoxAnnotation for why it is server-assigned and excluded from equality.
+    # Set on every subclass (via ``_server_assigned_id_field``) so callers can read
+    # it off the base type; server-assigned and excluded from equality.
     dataset_item_id: Optional[str]
 
     @classmethod
@@ -164,14 +178,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
     embedding_vector: Optional[list] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -294,14 +301,7 @@ class LineAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -398,14 +398,7 @@ class PolygonAnnotation(Annotation):
     embedding_vector: Optional[list] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -550,14 +543,7 @@ class KeypointsAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata or {}
@@ -733,14 +719,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -895,10 +874,7 @@ class SegmentationAnnotation(Annotation):
     reference_id: str
     annotation_id: Optional[str] = None
     # metadata: Optional[dict] = None # TODO(sc: 422637)
-    # See the note on BoxAnnotation.dataset_item_id — server-assigned, read-only.
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         if not self.mask_url:
@@ -1001,14 +977,7 @@ class CategoryAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -1050,14 +1019,7 @@ class MultiCategoryAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -1122,14 +1084,7 @@ class SceneCategoryAnnotation(Annotation):
     taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = field(default_factory=dict)
     _task_id: Optional[str] = field(default=None, repr=False)
-    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
-    # Server-assigned and read-only: populated on objects returned by the API, ``None``
-    # on ones you construct locally to upload, and never sent in ``to_payload``.
-    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
-    # round-tripped self (same reason as ``DatasetItem.phash``).
-    dataset_item_id: Optional[str] = field(
-        default=None, repr=False, compare=False
-    )
+    dataset_item_id: Optional[str] = _server_assigned_id_field()
 
     @classmethod
     def from_json(cls, payload: dict):

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -13,6 +13,7 @@ from .constants import (
     BOX_TYPE,
     CATEGORY_TYPE,
     CUBOID_TYPE,
+    DATASET_ITEM_ID_KEY,
     DIMENSIONS_KEY,
     EMBEDDING_VECTOR_KEY,
     GEOMETRY_KEY,
@@ -58,6 +59,9 @@ class Annotation:
     """
 
     reference_id: str
+    # Set on every subclass so callers can read it off the base type. See the note on
+    # BoxAnnotation for why it is server-assigned and excluded from equality.
+    dataset_item_id: Optional[str]
 
     @classmethod
     def from_json(cls, payload: dict):
@@ -160,6 +164,14 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
     embedding_vector: Optional[list] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -181,6 +193,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -281,6 +294,14 @@ class LineAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -311,6 +332,7 @@ class LineAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -376,6 +398,14 @@ class PolygonAnnotation(Annotation):
     embedding_vector: Optional[list] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -407,6 +437,7 @@ class PolygonAnnotation(Annotation):
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -519,6 +550,14 @@ class KeypointsAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata or {}
@@ -572,6 +611,7 @@ class KeypointsAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -693,6 +733,14 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -710,6 +758,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -846,6 +895,10 @@ class SegmentationAnnotation(Annotation):
     reference_id: str
     annotation_id: Optional[str] = None
     # metadata: Optional[dict] = None # TODO(sc: 422637)
+    # See the note on BoxAnnotation.dataset_item_id — server-assigned, read-only.
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         if not self.mask_url:
@@ -863,6 +916,7 @@ class SegmentationAnnotation(Annotation):
             ],
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
 
@@ -947,6 +1001,14 @@ class CategoryAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -960,6 +1022,7 @@ class CategoryAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -987,6 +1050,14 @@ class MultiCategoryAnnotation(Annotation):
     metadata: Optional[Dict] = None
     track_reference_id: Optional[str] = None
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         self.metadata = self.metadata if self.metadata else {}
@@ -1000,6 +1071,7 @@ class MultiCategoryAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:
@@ -1050,6 +1122,14 @@ class SceneCategoryAnnotation(Annotation):
     taxonomy_name: Optional[str] = None
     metadata: Optional[Dict] = field(default_factory=dict)
     _task_id: Optional[str] = field(default=None, repr=False)
+    # Nucleus-internal dataset item id (``di_*``) of the item this object sits on.
+    # Server-assigned and read-only: populated on objects returned by the API, ``None``
+    # on ones you construct locally to upload, and never sent in ``to_payload``.
+    # Excluded from ``__eq__`` so a locally-built object still compares equal to its
+    # round-tripped self (same reason as ``DatasetItem.phash``).
+    dataset_item_id: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     @classmethod
     def from_json(cls, payload: dict):
@@ -1059,6 +1139,7 @@ class SceneCategoryAnnotation(Annotation):
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             _task_id=payload.get(TASK_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
         )
 
     def to_payload(self) -> dict:

--- a/nucleus/annotation.py
+++ b/nucleus/annotation.py
@@ -60,9 +60,13 @@ def _server_assigned_id_field():
     ``to_payload``. Excluded from ``__eq__`` so a locally-built object still
     compares equal to its round-tripped self (same reason as
     ``DatasetItem.phash``).
+
+    ``kw_only`` keeps it off the positional signature: it is server-assigned, so
+    a caller passing it positionally would only have it silently dropped by
+    ``to_payload``.
     """
     # pylint: disable=invalid-field-call  # returned into a dataclass body below
-    return field(default=None, repr=False, compare=False)
+    return field(default=None, repr=False, compare=False, kw_only=True)
 
 
 class Annotation:
@@ -200,7 +204,7 @@ class BoxAnnotation(Annotation):  # pylint: disable=R0902
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -332,7 +336,7 @@ class LineAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -430,7 +434,7 @@ class PolygonAnnotation(Annotation):
             embedding_vector=payload.get(EMBEDDING_VECTOR_KEY, None),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -597,7 +601,7 @@ class KeypointsAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -737,7 +741,7 @@ class CuboidAnnotation(Annotation):  # pylint: disable=R0902
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -892,7 +896,7 @@ class SegmentationAnnotation(Annotation):
             ],
             reference_id=payload[REFERENCE_ID_KEY],
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
 
@@ -991,7 +995,7 @@ class CategoryAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -1033,7 +1037,7 @@ class MultiCategoryAnnotation(Annotation):
             metadata=payload.get(METADATA_KEY, {}),
             track_reference_id=payload.get(TRACK_REFERENCE_ID_KEY, None),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:
@@ -1094,7 +1098,7 @@ class SceneCategoryAnnotation(Annotation):
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             _task_id=payload.get(TASK_ID_KEY, None),
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def to_payload(self) -> dict:

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1584,6 +1584,7 @@ class Dataset:
                                 "width": int,
                                 "height": int,
                                 "key": str, # frame key
+                                "dataset_item_id": str, # id of the frame's dataset item
                                 "metadata": Dict[str, Any]
                             }]
                         }

--- a/nucleus/dataset.py
+++ b/nucleus/dataset.py
@@ -1584,7 +1584,7 @@ class Dataset:
                                 "width": int,
                                 "height": int,
                                 "key": str, # frame key
-                                "dataset_item_id": str, # id of the frame's dataset item
+                                "dataset_item_id": str, # internally generated id of the frame's dataset item
                                 "metadata": Dict[str, Any]
                             }]
                         }

--- a/nucleus/dataset_item.py
+++ b/nucleus/dataset_item.py
@@ -10,6 +10,7 @@ from .camera_params import CameraParams
 from .constants import (
     BACKEND_REFERENCE_ID_KEY,
     CAMERA_PARAMS_KEY,
+    DATASET_ITEM_ID_KEY,
     EMBEDDING_INFO_KEY,
     EMBEDDING_VECTOR_KEY,
     HEIGHT_KEY,
@@ -131,6 +132,11 @@ class DatasetItem:  # pylint: disable=R0902
     # returned object — so locally-constructed items would otherwise spuriously
     # differ from round-tripped ones.
     phash: Optional[str] = field(default=None, compare=False)
+    # Nucleus-internal dataset item id (``di_*``), assigned server-side. Populated on
+    # items returned by the API; ``None`` on items you construct locally to upload.
+    # Excluded from auto-generated __eq__ for the same reason as ``phash`` — a
+    # locally-built item would otherwise never compare equal to its round-tripped self.
+    dataset_item_id: Optional[str] = field(default=None, compare=False)
 
     def __post_init__(self):
         assert self.reference_id is not None, "reference_id is required."
@@ -187,6 +193,7 @@ class DatasetItem:  # pylint: disable=R0902
             reference_id=payload.get(REFERENCE_ID_KEY),
             metadata=payload.get(METADATA_KEY, {}),
             phash=payload.get(PHASH_KEY),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
         )
 
     def local_file_exists(self):

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -3,6 +3,7 @@ All of the prediction types supported. In general, prediction types are the same
 as annotation types, but come with additional, optional data that can be attached
 such as confidence or probability distributions.
 """
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Type, Union
 
@@ -28,6 +29,7 @@ from .constants import (
     CLASS_PDF_KEY,
     CONFIDENCE_KEY,
     CUBOID_TYPE,
+    DATASET_ITEM_ID_KEY,
     DIMENSIONS_KEY,
     EMBEDDING_VECTOR_KEY,
     GEOMETRY_KEY,
@@ -129,6 +131,7 @@ class SegmentationPrediction(SegmentationAnnotation):
                 for ann in payload.get(ANNOTATIONS_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
@@ -189,6 +192,7 @@ class BoxPrediction(BoxAnnotation):
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
@@ -197,6 +201,7 @@ class BoxPrediction(BoxAnnotation):
             width=width,
             height=height,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             annotation_id=annotation_id,
             metadata=metadata,
             embedding_vector=embedding_vector,
@@ -224,6 +229,7 @@ class BoxPrediction(BoxAnnotation):
             width=geometry.get(WIDTH_KEY, 0),
             height=geometry.get(HEIGHT_KEY, 0),
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -269,11 +275,13 @@ class LinePrediction(LineAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
             vertices=vertices,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             annotation_id=annotation_id,
             metadata=metadata,
             track_reference_id=track_reference_id,
@@ -299,6 +307,7 @@ class LinePrediction(LineAnnotation):
                 Point.from_json(_) for _ in geometry.get(VERTICES_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -347,11 +356,13 @@ class PolygonPrediction(PolygonAnnotation):
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
             vertices=vertices,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             annotation_id=annotation_id,
             metadata=metadata,
             embedding_vector=embedding_vector,
@@ -378,6 +389,7 @@ class PolygonPrediction(PolygonAnnotation):
                 Point.from_json(_) for _ in geometry.get(VERTICES_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -428,6 +440,7 @@ class KeypointsPrediction(KeypointsAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
@@ -435,6 +448,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             names=names,
             skeleton=skeleton,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             annotation_id=annotation_id,
             metadata=metadata,
             track_reference_id=track_reference_id,
@@ -462,6 +476,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             names=geometry[KEYPOINTS_NAMES_KEY],
             skeleton=geometry[KEYPOINTS_SKELETON_KEY],
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -509,6 +524,7 @@ class CuboidPrediction(CuboidAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
@@ -516,6 +532,7 @@ class CuboidPrediction(CuboidAnnotation):
             dimensions=dimensions,
             yaw=yaw,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             annotation_id=annotation_id,
             metadata=metadata,
             track_reference_id=track_reference_id,
@@ -541,6 +558,7 @@ class CuboidPrediction(CuboidAnnotation):
             dimensions=Point3D.from_json(geometry.get(DIMENSIONS_KEY, {})),
             yaw=geometry.get(YAW_KEY, 0),
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -580,11 +598,13 @@ class CategoryPrediction(CategoryAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
             taxonomy_name=taxonomy_name,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             metadata=metadata,
             track_reference_id=track_reference_id,
         )
@@ -606,6 +626,7 @@ class CategoryPrediction(CategoryAnnotation):
             label=payload.get(LABEL_KEY, 0),
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
@@ -649,11 +670,13 @@ class SceneCategoryPrediction(SceneCategoryAnnotation):
         taxonomy_name: Optional[str] = None,
         confidence: Optional[float] = None,
         metadata: Optional[Dict] = None,
+        dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
             label=label,
             taxonomy_name=taxonomy_name,
             reference_id=reference_id,
+            dataset_item_id=dataset_item_id,
             metadata=metadata,
         )
         self.confidence = confidence
@@ -671,6 +694,7 @@ class SceneCategoryPrediction(SceneCategoryAnnotation):
             label=payload.get(LABEL_KEY, 0),
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
             confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )

--- a/nucleus/prediction.py
+++ b/nucleus/prediction.py
@@ -131,7 +131,7 @@ class SegmentationPrediction(SegmentationAnnotation):
                 for ann in payload.get(ANNOTATIONS_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             # metadata=payload.get(METADATA_KEY, None),  # TODO(sc: 422637)
         )
@@ -192,6 +192,7 @@ class BoxPrediction(BoxAnnotation):
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -229,7 +230,7 @@ class BoxPrediction(BoxAnnotation):
             width=geometry.get(WIDTH_KEY, 0),
             height=geometry.get(HEIGHT_KEY, 0),
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -275,6 +276,7 @@ class LinePrediction(LineAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -307,7 +309,7 @@ class LinePrediction(LineAnnotation):
                 Point.from_json(_) for _ in geometry.get(VERTICES_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -356,6 +358,7 @@ class PolygonPrediction(PolygonAnnotation):
         class_pdf: Optional[Dict] = None,
         embedding_vector: Optional[list] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -389,7 +392,7 @@ class PolygonPrediction(PolygonAnnotation):
                 Point.from_json(_) for _ in geometry.get(VERTICES_KEY, [])
             ],
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -440,6 +443,7 @@ class KeypointsPrediction(KeypointsAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -476,7 +480,7 @@ class KeypointsPrediction(KeypointsAnnotation):
             names=geometry[KEYPOINTS_NAMES_KEY],
             skeleton=geometry[KEYPOINTS_SKELETON_KEY],
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -524,6 +528,7 @@ class CuboidPrediction(CuboidAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -558,7 +563,7 @@ class CuboidPrediction(CuboidAnnotation):
             dimensions=Point3D.from_json(geometry.get(DIMENSIONS_KEY, {})),
             yaw=geometry.get(YAW_KEY, 0),
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             annotation_id=payload.get(ANNOTATION_ID_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
@@ -598,6 +603,7 @@ class CategoryPrediction(CategoryAnnotation):
         metadata: Optional[Dict] = None,
         class_pdf: Optional[Dict] = None,
         track_reference_id: Optional[str] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -626,7 +632,7 @@ class CategoryPrediction(CategoryAnnotation):
             label=payload.get(LABEL_KEY, 0),
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
             class_pdf=payload.get(CLASS_PDF_KEY, None),
@@ -670,6 +676,7 @@ class SceneCategoryPrediction(SceneCategoryAnnotation):
         taxonomy_name: Optional[str] = None,
         confidence: Optional[float] = None,
         metadata: Optional[Dict] = None,
+        *,
         dataset_item_id: Optional[str] = None,
     ):
         super().__init__(
@@ -694,7 +701,7 @@ class SceneCategoryPrediction(SceneCategoryAnnotation):
             label=payload.get(LABEL_KEY, 0),
             taxonomy_name=payload.get(TAXONOMY_NAME_KEY, None),
             reference_id=payload[REFERENCE_ID_KEY],
-            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY, None),
+            dataset_item_id=payload.get(DATASET_ITEM_ID_KEY),
             confidence=payload.get(CONFIDENCE_KEY, None),
             metadata=payload.get(METADATA_KEY, {}),
         )

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -230,9 +230,6 @@ def format_scale_task_info_response(response: dict) -> Union[Dict, List[Dict]]:
             ret.append(row)
     return ret
 
-
-# One branch/statement per annotation type — stamping reference_id and
-# dataset_item_id onto each pushed it just over pylint's default ceilings.
 # pylint: disable=too-many-branches,too-many-statements
 def convert_export_payload(api_payload, has_predictions: bool = False):
     """Helper function to convert raw JSON to API objects

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -185,13 +185,19 @@ def format_dataset_item_response(response: dict) -> dict:
     item = response[ITEM_KEY]
     annotation_payload = response[ANNOTATIONS_KEY]
 
+    # The endpoint returns dataset_item_id on the item, not on each annotation,
+    # so stamp it down the same way convert_export_payload does — otherwise
+    # loc/refloc/iloc annotations would come back with it unset.
+    item_dataset_item_id = item.get(DATASET_ITEM_ID_KEY)
+
     annotation_response = {}
     for annotation_type in ANNOTATION_TYPES:
         if annotation_type in annotation_payload:
-            annotation_response[annotation_type] = [
-                Annotation.from_json(ann)
-                for ann in annotation_payload[annotation_type]
-            ]
+            annotations = []
+            for ann in annotation_payload[annotation_type]:
+                ann[DATASET_ITEM_ID_KEY] = item_dataset_item_id
+                annotations.append(Annotation.from_json(ann))
+            annotation_response[annotation_type] = annotations
     return {
         ITEM_KEY: DatasetItem.from_json(item),
         ANNOTATIONS_KEY: annotation_response,

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -225,7 +225,9 @@ def format_scale_task_info_response(response: dict) -> Union[Dict, List[Dict]]:
     return ret
 
 
-# pylint: disable=too-many-branches
+# One branch/statement per annotation type — stamping reference_id and
+# dataset_item_id onto each pushed it just over pylint's default ceilings.
+# pylint: disable=too-many-branches,too-many-statements
 def convert_export_payload(api_payload, has_predictions: bool = False):
     """Helper function to convert raw JSON to API objects
 

--- a/nucleus/utils.py
+++ b/nucleus/utils.py
@@ -31,6 +31,7 @@ from .constants import (
     BOX_TYPE,
     CATEGORY_TYPE,
     CUBOID_TYPE,
+    DATASET_ITEM_ID_KEY,
     EXPORTED_SCALE_TASK_INFO_ROWS,
     ITEM_KEY,
     KEYPOINTS_TYPE,
@@ -239,10 +240,15 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
     for row in api_payload:
         return_payload_row = {}
         return_payload_row[ITEM_KEY] = DatasetItem.from_json(row[ITEM_KEY])
+        # The backend returns reference_id and dataset_item_id on the item, not on each
+        # object, so stamp both down onto every annotation/prediction below.
+        item_reference_id = row[ITEM_KEY][REFERENCE_ID_KEY]
+        item_dataset_item_id = row[ITEM_KEY].get(DATASET_ITEM_ID_KEY)
         annotations = defaultdict(list)
         if row.get(SEGMENTATION_TYPE) is not None:
             segmentation = row[SEGMENTATION_TYPE]
-            segmentation[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            segmentation[REFERENCE_ID_KEY] = item_reference_id
+            segmentation[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[
                     SEGMENTATION_TYPE
@@ -252,7 +258,8 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
                     SEGMENTATION_TYPE
                 ] = SegmentationPrediction.from_json(segmentation)
         for polygon in row[POLYGON_TYPE]:
-            polygon[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            polygon[REFERENCE_ID_KEY] = item_reference_id
+            polygon[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[POLYGON_TYPE].append(
                     PolygonAnnotation.from_json(polygon)
@@ -262,13 +269,15 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
                     PolygonPrediction.from_json(polygon)
                 )
         for line in row[LINE_TYPE]:
-            line[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            line[REFERENCE_ID_KEY] = item_reference_id
+            line[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[LINE_TYPE].append(LineAnnotation.from_json(line))
             else:
                 annotations[LINE_TYPE].append(LinePrediction.from_json(line))
         for keypoints in row[KEYPOINTS_TYPE]:
-            keypoints[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            keypoints[REFERENCE_ID_KEY] = item_reference_id
+            keypoints[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[KEYPOINTS_TYPE].append(
                     KeypointsAnnotation.from_json(keypoints)
@@ -278,13 +287,15 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
                     KeypointsPrediction.from_json(keypoints)
                 )
         for box in row[BOX_TYPE]:
-            box[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            box[REFERENCE_ID_KEY] = item_reference_id
+            box[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[BOX_TYPE].append(BoxAnnotation.from_json(box))
             else:
                 annotations[BOX_TYPE].append(BoxPrediction.from_json(box))
         for cuboid in row[CUBOID_TYPE]:
-            cuboid[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            cuboid[REFERENCE_ID_KEY] = item_reference_id
+            cuboid[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[CUBOID_TYPE].append(
                     CuboidAnnotation.from_json(cuboid)
@@ -294,7 +305,8 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
                     CuboidPrediction.from_json(cuboid)
                 )
         for category in row[CATEGORY_TYPE]:
-            category[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            category[REFERENCE_ID_KEY] = item_reference_id
+            category[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             if not has_predictions:
                 annotations[CATEGORY_TYPE].append(
                     CategoryAnnotation.from_json(category)
@@ -304,7 +316,8 @@ def convert_export_payload(api_payload, has_predictions: bool = False):
                     CategoryPrediction.from_json(category)
                 )
         for multicategory in row[MULTICATEGORY_TYPE]:
-            multicategory[REFERENCE_ID_KEY] = row[ITEM_KEY][REFERENCE_ID_KEY]
+            multicategory[REFERENCE_ID_KEY] = item_reference_id
+            multicategory[DATASET_ITEM_ID_KEY] = item_dataset_item_id
             annotations[MULTICATEGORY_TYPE].append(
                 MultiCategoryAnnotation.from_json(multicategory)
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.20.0"
+version = "0.20.1"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,3 +146,57 @@ def test_dataset_item_id_populates_from_dataset_item_json():
     )
     assert item.dataset_item_id == DI_ID
     assert "dataset_item_id" not in item.to_payload()
+
+
+def test_format_dataset_item_response_stamps_dataset_item_id():
+    """Single-item loc/refloc/iloc annotations carry the id like exports do."""
+    response = {
+        "item": {
+            "url": "https://example.com/a.jpg",
+            "reference_id": REF_ID,
+            "dataset_item_id": DI_ID,
+        },
+        "annotations": {
+            "box": [BoxAnnotation("car", 0, 0, 4, 4, REF_ID).to_payload()]
+        },
+    }
+    out = utils.format_dataset_item_response(response)
+    assert out["item"].dataset_item_id == DI_ID
+    assert out["annotations"]["box"][0].dataset_item_id == DI_ID
+
+
+def test_format_dataset_item_response_none_when_backend_omits_id():
+    response = {
+        "item": {"url": "https://example.com/a.jpg", "reference_id": REF_ID},
+        "annotations": {
+            "box": [BoxAnnotation("car", 0, 0, 4, 4, REF_ID).to_payload()]
+        },
+    }
+    out = utils.format_dataset_item_response(response)
+    assert out["annotations"]["box"][0].dataset_item_id is None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda di: BoxAnnotation(
+            "car", 0, 0, 4, 4, REF_ID, dataset_item_id=di
+        ),
+        lambda di: BoxPrediction(
+            "car", 0, 0, 4, 4, REF_ID, dataset_item_id=di
+        ),
+    ],
+)
+def test_dataset_item_id_is_keyword_only(factory):
+    """Server-assigned, so it must be passed by keyword, never positionally."""
+    # Keyword works.
+    assert factory("di_kw").dataset_item_id == "di_kw"
+
+
+def test_dataset_item_id_rejected_positionally():
+    """A positional value would be silently dropped by to_payload — block it."""
+    with pytest.raises(TypeError):
+        # One arg past track_reference_id would land on the old positional slot.
+        BoxPrediction(
+            "car", 0, 0, 4, 4, REF_ID, 0.9, "a1", {}, {}, None, None, "di_x"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,19 @@ import io
 
 import pytest
 
-from nucleus import DatasetItem, utils
+from nucleus import (
+    BoxAnnotation,
+    BoxPrediction,
+    CategoryAnnotation,
+    CategoryPrediction,
+    DatasetItem,
+    LineAnnotation,
+    LinePrediction,
+    Point,
+    PolygonAnnotation,
+    PolygonPrediction,
+    utils,
+)
 
 
 class TestNonSerializableObject:
@@ -36,3 +48,101 @@ def test_serialize():
         test_items[1].metadata["bad"] = "fixed"
 
         utils.serialize_and_write(test_items, in_memory_filelike)
+
+
+# --------------------------------------------------------------------------- #
+# convert_export_payload: dataset_item_id propagation (offline, no live API)
+# --------------------------------------------------------------------------- #
+REF_ID = "ref_1"
+DI_ID = "di_abc123"
+
+
+def _annotation_payloads():
+    """Minimal but valid per-type payloads, keyed by the export-row type key.
+
+    Built by serializing real annotation objects so the shapes stay in sync
+    with ``from_json`` — reference_id/dataset_item_id are omitted here because
+    the backend returns them on the item, not per object.
+    """
+    verts = [Point(0, 0), Point(1, 0), Point(1, 1)]
+    return {
+        "box": BoxAnnotation("car", 0, 0, 4, 4, REF_ID).to_payload(),
+        "polygon": PolygonAnnotation("car", verts, REF_ID).to_payload(),
+        "line": LineAnnotation("lane", verts, REF_ID).to_payload(),
+        "category": CategoryAnnotation("car", "vehicles", REF_ID).to_payload(),
+    }
+
+
+def _export_row(dataset_item_id=DI_ID, with_objects=True):
+    """One row shaped like the batch-export endpoint returns."""
+    payloads = _annotation_payloads() if with_objects else {}
+    item = {"url": "https://example.com/a.jpg", "reference_id": REF_ID}
+    if dataset_item_id is not None:
+        item["dataset_item_id"] = dataset_item_id
+    return {
+        "item": item,
+        "annotations": [],
+        "segmentation": None,
+        "box": [payloads["box"]] if with_objects else [],
+        "polygon": [payloads["polygon"]] if with_objects else [],
+        "line": [payloads["line"]] if with_objects else [],
+        "keypoints": [],
+        "cuboid": [],
+        "category": [payloads["category"]] if with_objects else [],
+        "multicategory": [],
+    }
+
+
+@pytest.mark.parametrize("obj_type", ["box", "polygon", "line", "category"])
+def test_convert_export_stamps_dataset_item_id_on_annotations(obj_type):
+    result = utils.convert_export_payload([_export_row()])
+    item = result[0]["item"]
+    obj = result[0]["annotations"][obj_type][0]
+    assert item.dataset_item_id == DI_ID
+    assert obj.dataset_item_id == DI_ID
+    assert obj.reference_id == REF_ID
+
+
+@pytest.mark.parametrize("obj_type", ["box", "polygon", "line", "category"])
+def test_convert_export_stamps_dataset_item_id_on_predictions(obj_type):
+    result = utils.convert_export_payload(
+        [_export_row()], has_predictions=True
+    )
+    obj = result[0]["predictions"][obj_type][0]
+    assert obj.dataset_item_id == DI_ID
+    assert obj.reference_id == REF_ID
+
+
+def test_convert_export_leaves_dataset_item_id_none_when_backend_omits_it():
+    """An un-upgraded backend that omits the id must not raise."""
+    result = utils.convert_export_payload([_export_row(dataset_item_id=None)])
+    assert result[0]["item"].dataset_item_id is None
+    for obj_type in ("box", "polygon", "line", "category"):
+        assert result[0]["annotations"][obj_type][0].dataset_item_id is None
+
+
+def test_dataset_item_id_is_read_only_on_annotations():
+    """Server-assigned: excluded from __eq__ and never sent in to_payload."""
+    exported = utils.convert_export_payload([_export_row()])[0]["annotations"][
+        "box"
+    ][0]
+    local = BoxAnnotation("car", 0, 0, 4, 4, REF_ID)
+
+    # Equal despite the exported copy carrying an id the local one lacks.
+    assert local.dataset_item_id is None
+    assert exported.dataset_item_id == DI_ID
+    assert exported == local
+    # The id is not part of the upload contract.
+    assert "dataset_item_id" not in exported.to_payload()
+
+
+def test_dataset_item_id_populates_from_dataset_item_json():
+    item = DatasetItem.from_json(
+        {
+            "url": "https://example.com/a.jpg",
+            "reference_id": REF_ID,
+            "dataset_item_id": DI_ID,
+        }
+    )
+    assert item.dataset_item_id == DI_ID
+    assert "dataset_item_id" not in item.to_payload()


### PR DESCRIPTION
Batch exports only ever returned `reference_id` on the exported item, so keying an exported prediction back to a Nucleus dataset item meant a second lookup.

This is an **inconsistency fix, not a new field**: the single-item endpoints (`/dataset/:id/loc`, `/refloc`, `/iloc`) already return `dataset_item_id`, and the public API docs (`ApiDocsPage/slices/batch-export.md`) already document it in the batch-export response. The batch export was the odd one out.

Pairs with scaleapi PR: `luke/nucleus-export-dataset-item-id`.

## What changed

`dataset_item_id` now appears everywhere `reference_id` already does:

- `DatasetItem` gains the field, wired through `from_json` — the single deserialization entry point, so every SDK path that returns an item picks it up, not just exports.
- Every `Annotation` / `Prediction` subclass gains it (`box`, `line`, `polygon`, `keypoints`, `cuboid`, `category`, `multicategory`, `segmentation`). `convert_export_payload` stamps it down from the item exactly as it already does for `reference_id`.
- The scene/video export docstring documents it on each track frame.

## Read-only semantics

The field is server-assigned, and mirrors how `DatasetItem.phash` was done:

| | behaviour |
|---|---|
| `from_json` | populated |
| locally constructed | `None` |
| `__eq__` | excluded (`compare=False`) |
| `to_payload` | absent — uploads unchanged |

The `__eq__` exclusion matters: without it, every existing test that compares a locally-built annotation against its round-tripped twin would start failing.

Exports from a backend that doesn't return the field leave it `None` rather than throwing, so this SDK version is safe against an un-upgraded backend.

## Verification

The test suite requires live API keys (`conftest.py` hard-asserts on `NUCLEUS_PYTEST_API_KEY`), so it could not be run locally. Verified offline instead by driving `convert_export_payload` directly:

- every geometry type on both the annotation and prediction paths carries the id
- a local object still compares equal to its round-tripped self
- `to_payload` output is unchanged
- an item payload with no `dataset_item_id` yields `None` everywhere and does not raise

Formatted with the repo-pinned black 23.12.1 (a newer local black introduced unrelated reformatting, which was reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the server-assigned `dataset_item_id` throughout deserialized dataset items, annotations, and predictions without adding it to upload payloads or equality comparisons.
- Adds read-only `dataset_item_id` fields to dataset-item and object models.
- Propagates the item identifier through batch and single-item response conversion.
- Adds offline coverage for annotation and prediction propagation, backward compatibility with older backends, and serialization behavior.
- Documents the identifier in scene/video export frames and the changelog.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| nucleus/annotation.py | Adds a keyword-only, read-only dataset item identifier to all annotation models and populates it during deserialization. |
| nucleus/prediction.py | Extends prediction constructors and deserializers to preserve the server-returned dataset item identifier without changing existing positional parameters. |
| nucleus/dataset_item.py | Adds the non-comparing dataset item identifier to deserialized `DatasetItem` objects while keeping upload payloads unchanged. |
| nucleus/utils.py | Propagates the item-level identifier into converted annotations and predictions across batch and single-item response paths. |
| tests/test_utils.py | Adds offline tests for identifier propagation, omitted backend values, equality, keyword-only construction, and unchanged upload serialization. |
| nucleus/dataset.py | Documents `dataset_item_id` on scene and video track frames. |
| CHANGELOG.md | Documents the new SDK exposure and its read-only compatibility semantics. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Backend export response] --> B[DatasetItem.from_json]
    A --> C[Response conversion]
    C --> D[Annotation.from_json]
    C --> E[Prediction.from_json]
    B --> F[DatasetItem.dataset_item_id]
    D --> G[Annotation.dataset_item_id]
    E --> H[Prediction.dataset_item_id]
    F -. omitted .-> I[to_payload]
    G -. omitted .-> I
    H -. omitted .-> I
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;master&#39; into lukeschaefer/..."](https://github.com/scaleapi/nucleus-python-client/commit/1a51b948364e840221ed36a0e92846634b97f76c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54025623)</sub>

<!-- /greptile_comment -->