### PR TITLE
chore: bump pyproject version to 0.21.2 to match CHANGELOG + v0.21.2 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.21.0) - 2026-08-17
+## [0.21.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.21.2) - 2026-08-17
 
 ### Added
 - **Benchmark versioning / lineage.** `create_benchmark()` accepts `parent_benchmark_id` to create a new **version** downstream of an existing benchmark: the child inherits the parent's items, the source arguments add on top, and `removed_item_ids` prune inherited items (`parent ∪ added ∖ removed`). Version defaults to a minor bump; pass `bump_type="major"` or explicit `version_major` + `version_minor` (must exceed the parent's). `Benchmark` now exposes `parent_benchmark_id`, `version_major`, `version_minor`, and `version_label`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.21.0"
+version = "0.21.2"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the package metadata to version 0.21.2 and corrects the corresponding changelog release link.
- Changes the Poetry package version from 0.21.0 to 0.21.2.
- Points the 0.21.2 changelog entry to the v0.21.2 release.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both changes consistently align the package and changelog with release v0.21.2.

The release workflow reads the version directly from pyproject.toml, while runtime and documentation consumers use installed package metadata, so no additional version artifact is left stale.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Aligns the authoritative package version with the v0.21.2 release tag and existing changelog entry. |
| CHANGELOG.md | Corrects the 0.21.2 release URL so it points to the matching tag. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump pyproject version to 0.21.2 ..."](https://github.com/scaleapi/nucleus-python-client/commit/576aabacb69fc217d9d3bc39d45f959f0ee94f7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55630696)</sub>

<!-- /greptile_comment -->