### PR TITLE
feat(model): Model.model_runs() — list a model's run ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the [Nucleus Python Client](https://github.com/scaleapi/n
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.3](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.21.3) - 2026-08-25
+
+### Added
+- **`Model.model_runs()`.** Lists the ids of every model run for a model — the model-scoped counterpart to `Dataset.model_runs()`, which only lists a single dataset's runs. Pass `include_versions=True` to union runs across the model's version lineage (its version root and all descendants). Results are scoped server-side to runs on datasets you can read.
+
+  ```python
+  run_ids = model.model_runs()
+  ```
+
+> **Server dependency:** requires the `GET /nucleus/model/:modelId/modelRun` route in scaleapi. Unit tests pass regardless; live calls 404 until that deploys.
+
 ## [0.21.2](https://github.com/scaleapi/nucleus-python-client/releases/tag/v0.21.2) - 2026-08-17
 
 ### Added

--- a/nucleus/model.py
+++ b/nucleus/model.py
@@ -229,6 +229,25 @@ class Model:
             run.add_predictions(predictions)
         return run
 
+    def model_runs(self, include_versions: bool = False) -> List[str]:
+        """List the ids of every model run for this model. ::
+
+            run_ids = model.model_runs()
+
+        Args:
+            include_versions: Also include runs from other versions in this
+                model's lineage — its version root and all descendants. Defaults
+                to False, returning only runs whose ``model_id`` is this model.
+
+        Returns:
+            The model run ids (``run_*``). Scoped server-side to runs on datasets
+            you can read, so a run on a dataset you can't access is omitted.
+        """
+        route = f"model/{self.id}/modelRun"
+        if include_versions:
+            route += "?family=true"
+        return self._client.make_request({}, route, requests.get)
+
     def evaluate(self, scenario_test_names: List[str]) -> AsyncJob:
         """Evaluates this on the specified Unit Tests. ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = ["E501", "E741", "E731", "F401"]  # Easy ignore for getting it running 
 
 [tool.poetry]
 name = "scale-nucleus"
-version = "0.21.2"
+version = "0.21.3"
 description = "The official Python client library for Nucleus, the Data Platform for AI"
 license =  "MIT"
 authors = ["Scale AI Nucleus Team <nucleusapi@scaleapi.com>"]

--- a/tests/test_model_runs_listing.py
+++ b/tests/test_model_runs_listing.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+import requests
+
+from nucleus import Model
+
+
+def _model_with_client():
+    client = MagicMock()
+    model = Model(
+        model_id="prj_123",
+        name="my-model",
+        reference_id="my-ref",
+        metadata=None,
+        client=client,
+    )
+    return model, client
+
+
+def test_model_runs_returns_ids_and_hits_the_route():
+    model, client = _model_with_client()
+    client.make_request.return_value = ["run_a", "run_b"]
+
+    result = model.model_runs()
+
+    assert result == ["run_a", "run_b"]
+    payload, route, requests_command = client.make_request.call_args.args
+    assert payload == {}
+    assert route == "model/prj_123/modelRun"
+    assert requests_command is requests.get
+
+
+def test_model_runs_include_versions_appends_family_query():
+    model, client = _model_with_client()
+    client.make_request.return_value = []
+
+    model.model_runs(include_versions=True)
+
+    _, route, _ = client.make_request.call_args.args
+    assert route == "model/prj_123/modelRun?family=true"


### PR DESCRIPTION
## Summary

Adds `Model.model_runs()` — the model-scoped counterpart to `Dataset.model_runs()`, which only lists a single dataset's runs. Hits the new `GET /nucleus/model/:modelId/modelRun` route.

```python
run_ids = model.model_runs()                       # runs whose model_id is this model
run_ids = model.model_runs(include_versions=True)  # union across the version lineage (?family=true)
```

- `nucleus/model.py` — new `model_runs(include_versions=False) -> List[str]`, delegates to `make_request({}, "model/{id}/modelRun", requests.get)` (mirrors `Dataset.model_runs`).
- Results are scoped server-side to runs on datasets the caller can read.
- `tests/test_model_runs_listing.py` — mock unit tests: returns the ids / hits the right route, and `include_versions=True` appends `?family=true`.
- CHANGELOG `0.21.3` + `pyproject` version bump.

## Test Plan

- `pytest tests/test_model_runs_listing.py` → 2 passed. `black`/`isort` clean.
- Live call 404s until the server route (**scaleapi#158386**) deploys — noted in the CHANGELOG.

## Server dependency

Pairs with scaleapi#158386 (`GET /nucleus/model/:modelId/modelRun`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a model-scoped API for listing run IDs, with optional inclusion of runs across the model’s version lineage. The change also adds focused route tests and releases the API as version 0.21.3.
- Adds `Model.model_runs(include_versions=False)`.
- Sends `family=true` when version-lineage runs are requested.
- Adds unit tests for returned IDs and both route variants.
- Updates the package version and changelog.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete client-side defects identified in the new model-run listing path.

The route construction, GET delegation, optional lineage query, return contract, tests, documentation, and package version are internally consistent.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| nucleus/model.py | Adds the model-run listing method using the existing shared request transport; no actionable defect was identified. |
| tests/test_model_runs_listing.py | Covers the default route, lineage query parameter, HTTP verb, payload, and returned run IDs. |
| pyproject.toml | Advances the package version from 0.21.2 to 0.21.3. |
| CHANGELOG.md | Documents the new method, lineage option, access scoping, and acknowledged server deployment dependency. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(model): add Model.model\_runs() to l..."](https://github.com/scaleapi/nucleus-python-client/commit/ac0ebb857532a5e17bf8f5dbef76e3abe5da4538) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58757501)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Connection and request behavior](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/nucleus-python-client/-/docs/client-connection.md)
- Knowledge Base — [Model workflows](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/nucleus-python-client/-/docs/model-workflows.md)
- Knowledge Base — [Model runs, weights, and predictions](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/nucleus-python-client/-/docs/model-runs-and-predictions.md)
</details>


<!-- /greptile_comment -->